### PR TITLE
Added basic detector source in preparation for Haystack metrics.

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetector.java
@@ -66,6 +66,10 @@ public final class EwmaAnomalyDetector extends BasicAnomalyDetector<EwmaParams> 
         this(UUID.randomUUID(), new EwmaParams());
     }
     
+    public EwmaAnomalyDetector(UUID uuid) {
+        this(uuid, new EwmaParams());
+    }
+    
     public EwmaAnomalyDetector(EwmaParams params) {
         this(UUID.randomUUID(), params);
     }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/BasicDetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/BasicDetectorSource.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect.source;
+
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector;
+import com.expedia.metrics.MetricDefinition;
+import com.expedia.metrics.metrictank.MetricTankIdFactory;
+import lombok.val;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * A basic {@link DetectorSource} implementation that maps every metric to a single EWMA detector, managed in-memory.
+ *
+ * @author Willie Wheeler
+ */
+public final class BasicDetectorSource implements DetectorSource {
+    private MetricTankIdFactory idFactory = new MetricTankIdFactory();
+    private Map<UUID, AnomalyDetector> detectorMap = new HashMap<>();
+    
+    @Override
+    public List<UUID> findDetectorUUIDs(MetricDefinition metricDefinition) {
+        notNull(metricDefinition, "metricDefinition can't be null");
+        val id = idFactory.getId(metricDefinition);
+        val uuid = UUID.nameUUIDFromBytes(id.getBytes());
+        return Collections.singletonList(uuid);
+    }
+    
+    @Override
+    public AnomalyDetector findDetector(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        AnomalyDetector detector = detectorMap.get(uuid);
+        if (detector == null) {
+            detector = new EwmaAnomalyDetector(uuid);
+            detectorMap.put(uuid, detector);
+        }
+        return detector;
+    }
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorSource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect.source;
+
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
+import com.expedia.metrics.MetricDefinition;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DetectorSource {
+    
+    List<UUID> findDetectorUUIDs(MetricDefinition metricDefinition);
+    
+    AnomalyDetector findDetector(UUID uuid);
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/ModelServiceDetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/ModelServiceDetectorSource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect.source;
+
+import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
+import com.expedia.metrics.MetricDefinition;
+
+import java.util.List;
+import java.util.UUID;
+
+public class ModelServiceDetectorSource implements DetectorSource {
+    
+    @Override
+    public List<UUID> findDetectorUUIDs(MetricDefinition metricDefinition) {
+        return null;
+    }
+    
+    @Override
+    public AnomalyDetector findDetector(UUID uuid) {
+        return null;
+    }
+}

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/BasicDetectorSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/BasicDetectorSourceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect.source;
+
+import com.expedia.metrics.MetricDefinition;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@Slf4j
+public final class BasicDetectorSourceTest {
+    private BasicDetectorSource source;
+    private MetricDefinition metricDef1;
+    private MetricDefinition metricDef2;
+    
+    @Before
+    public void setUp() {
+        this.source = new BasicDetectorSource();
+        this.metricDef1 = new MetricDefinition("some-metric-1");
+        this.metricDef2 = new MetricDefinition("some-metric-2");
+    }
+    
+    @Test
+    public void testFindDetectorUUIDs_sameMetricHasSameUUID() {
+        val results1 = source.findDetectorUUIDs(metricDef1);
+        val results2 = source.findDetectorUUIDs(metricDef1);
+    
+        assertEquals(1, results1.size());
+        assertEquals(1, results2.size());
+    
+        val uuid1 = results1.get(0);
+        val uuid2 = results2.get(0);
+        
+        log.info("Same metric has same UUID:");
+        log.info("  uuid1={}", uuid1);
+        log.info("  uuid2={}", uuid2);
+    
+        assertEquals(uuid2, uuid1);
+    }
+    
+    @Test
+    public void testFindDetectorUUIDs_differentMetricsHaveDifferentUUIDs() {
+        val results1 = source.findDetectorUUIDs(metricDef1);
+        val results2 = source.findDetectorUUIDs(metricDef2);
+        
+        assertEquals(1, results1.size());
+        assertEquals(1, results2.size());
+    
+        val uuid1 = results1.get(0);
+        val uuid2 = results2.get(0);
+        
+        log.info("Different metrics have different UUIDs:");
+        log.info("  uuid1={}", uuid1);
+        log.info("  uuid2={}", uuid2);
+        
+        assertNotEquals(uuid2, uuid1);
+    }
+    
+    @Test
+    public void testFindDetector() {
+        val uuid = UUID.randomUUID();
+        val detector = source.findDetector(uuid);
+        
+        assertEquals(uuid, detector.getUuid());
+    }
+}


### PR DESCRIPTION
This commit adds a basic detector source that handles both detector UUID
generation and UUID-based detector lookup. We generate UUIDs dynamically
and consistently for a given MetricDefinition. Once we have a detector
UUID, we use that to create/retrieve an in-memory EWMA detector.

The AD Mapper will use UUID generation, and the AD Manager will use UUID-
based detector lookup. This will follow in a subsequent commit.

This allows us to map EWMA detectors to any incoming metric without any
user intervention, and without going to the model service.