### PR TITLE
DRY up detector registry

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorLookup.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorLookup.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.anomdetect;
+
+import com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdAnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.cusum.CusumAnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.individuals.IndividualsControlChartAnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.pewma.PewmaAnomalyDetector;
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
+
+/**
+ * Detector lookup table.
+ *
+ * @author Willie Wheeler
+ */
+public class DetectorLookup {
+    private final Map<String, Class<? extends AnomalyDetector>> detectorMap = new HashMap<>();
+    
+    public DetectorLookup() {
+        detectorMap.put("constant-detector", ConstantThresholdAnomalyDetector.class);
+        detectorMap.put("cusum-detector", CusumAnomalyDetector.class);
+        detectorMap.put("ewma-detector", EwmaAnomalyDetector.class);
+        detectorMap.put("holtwinters-detector", HoltWintersAnomalyDetector.class);
+        detectorMap.put("individuals-detector", IndividualsControlChartAnomalyDetector.class);
+        detectorMap.put("pewma-detector", PewmaAnomalyDetector.class);
+    }
+    
+    public Class<? extends AnomalyDetector> getDetector(String key) {
+        notNull(key, "key can't be null");
+        val detectorClass = detectorMap.get(key);
+        
+        if (detectorClass == null) {
+            throw new RuntimeException("No such detector: " + key);
+        }
+        
+        return detectorClass;
+    }
+}

--- a/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
+++ b/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
@@ -9,12 +9,5 @@ ad-manager {
   health.status.path = "/app/isHealthy"
   inbound-topic = "mapped-metrics"
   outbound-topic = "anomalies"
-  detector-class-map {
-    constant-detector = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdAnomalyDetector"
-    cusum-detector = "com.expedia.adaptivealerting.anomdetect.cusum.CusumAnomalyDetector"
-    ewma-detector = "com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector"
-    pewma-detector = "com.expedia.adaptivealerting.anomdetect.pewma.PewmaAnomalyDetector"
-    holtwinters-detector = "com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAnomalyDetector"
-  }
   model-service-uri-template = "${modelservice_uri_template}"
 }

--- a/deployment/terraform/ad-mapper/templates/ad-mapper_conf.tpl
+++ b/deployment/terraform/ad-mapper/templates/ad-mapper_conf.tpl
@@ -8,12 +8,5 @@ ad-mapper {
   health.status.path = "/app/isHealthy"
   inbound-topic = "aa-metrics"
   outbound-topic = "mapped-metrics"
-  detector-class-map {
-    constant-detector = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdAnomalyDetector"
-    cusum-detector = "com.expedia.adaptivealerting.anomdetect.cusum.CusumAnomalyDetector"
-    ewma-detector = "com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector"
-    pewma-detector = "com.expedia.adaptivealerting.anomdetect.pewma.PewmaAnomalyDetector"
-    holtwinters-detector = "com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAnomalyDetector"
-  }
   model-service-uri-template = "${modelservice_uri_template}"
 }

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -9,8 +9,6 @@ kstream.app.default {
   health.status.path = "/app/isHealthy"
 }
 
-# TODO DRY up the ad-mapper and ad-manager config. [WLW]
-
 ad-mapper {
   streams {
     application.id = "ad-mapper"
@@ -20,12 +18,6 @@ ad-mapper {
   }
   inbound-topic = "metrics"
   outbound-topic = "mapped-metrics"
-  detector-class-map {
-    constant-detector = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdAnomalyDetector"
-    cusum-detector = "com.expedia.adaptivealerting.anomdetect.cusum.CusumAnomalyDetector"
-    ewma-detector = "com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector"
-    pewma-detector = "com.expedia.adaptivealerting.anomdetect.pewma.PewmaAnomalyDetector"
-  }
   model-service-uri-template = "http://modelservice:8008/api/detectors/search/findByMetricHash?hash=%s"
 }
 
@@ -37,12 +29,6 @@ ad-manager {
   }
   inbound-topic = "mapped-metrics"
   outbound-topic = "anomalies"
-  detector-class-map {
-    constant-detector = "com.expedia.adaptivealerting.anomdetect.constant.ConstantThresholdAnomalyDetector"
-    cusum-detector = "com.expedia.adaptivealerting.anomdetect.cusum.CusumAnomalyDetector"
-    ewma-detector = "com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector"
-    pewma-detector = "com.expedia.adaptivealerting.anomdetect.pewma.PewmaAnomalyDetector"
-  }
   model-service-uri-template = "http://modelservice:8008/api/models/search/findByMetricHash?hash=%s"
 }
 


### PR DESCRIPTION
Previously the detector registry was defined in multiple config files.
It's the same registry across all apps, so there's no need for that.
Moreover, there's not really any need for this to be config files, since
the detector registry is wholly dependent on the built-in detectors
available. So I just implemented a DetectorLookup class. When people
create new detectors they need to create an entry in this class.