### PR TITLE
Stop pushing non-anomalous metrics to the anomalies topic.

### DIFF
--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaAnomalyDetectorMapper.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaAnomalyDetectorMapper.java
@@ -16,11 +16,13 @@
 package com.expedia.adaptivealerting.kafka;
 
 import com.expedia.adaptivealerting.anomdetect.DetectorMapper;
-import com.expedia.adaptivealerting.kafka.serde.JsonPojoSerde;
+import com.expedia.adaptivealerting.core.data.MappedMetricData;
+import com.expedia.adaptivealerting.kafka.serde.MappedMetricDataJsonSerde;
 import com.expedia.adaptivealerting.kafka.util.DetectorUtil;
 import com.expedia.metrics.MetricData;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -33,13 +35,18 @@ import java.util.stream.Collectors;
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 
 /**
- * Kafka Streams adapter for {@link DetectorMapper}.
+ * Kafka Streams adapter for {@link DetectorMapper}. Reads metric data from an input topic, classifies individual metric
+ * data points, and publishes the classifications to an anomalies output topic.
  */
 @Slf4j
 public final class KafkaAnomalyDetectorMapper extends AbstractStreamsApp {
     private static final String CK_AD_MAPPER = "ad-mapper";
     
     private final DetectorMapper mapper;
+    
+    // TODO Make these configurable. [WLW]
+    private Serde<String> outputKeySerde = new Serdes.StringSerde();
+    private Serde<MappedMetricData> outputValueSerde = new MappedMetricDataJsonSerde();
     
     public static void main(String[] args) {
         val config = new TypesafeConfigLoader(CK_AD_MAPPER).loadMergedConfig();
@@ -72,19 +79,25 @@ public final class KafkaAnomalyDetectorMapper extends AbstractStreamsApp {
         val builder = new StreamsBuilder();
         final KStream<String, MetricData> stream = builder.stream(inboundTopic);
         stream
-                .flatMap((key, metricData) -> {
-                    log.trace("Mapping key={}, metricData={}", key, metricData);
-                    val mappedMetricDataSet = mapper.map(metricData);
-                    return mappedMetricDataSet.stream()
-                            .map(mappedMetricData -> {
-                                val newKey = mappedMetricData.getDetectorUuid().toString();
-                                return KeyValue.pair(newKey, mappedMetricData);
-                            })
-                            .collect(Collectors.toSet());
-                })
-                // TODO Make outbound serde configurable. [WLW]
-                .to(outboundTopic, Produced.with(new Serdes.StringSerde(), new JsonPojoSerde<>()));
-        
+                .filter((key, md) -> md != null)
+                .flatMap(this::metricsByDetector)
+                .to(outboundTopic, Produced.with(outputKeySerde, outputValueSerde));
         return builder.build();
+    }
+    
+    private Iterable<? extends KeyValue<String, MappedMetricData>> metricsByDetector(
+            String key,
+            MetricData metricData) {
+        
+        assert metricData != null;
+        log.trace("Mapping key={}, metricData={}", key, metricData);
+        
+        val mmdSet = mapper.map(metricData);
+        return mmdSet.stream()
+                .map(mmd -> {
+                    val newKey = mmd.getDetectorUuid().toString();
+                    return KeyValue.pair(newKey, mmd);
+                })
+                .collect(Collectors.toSet());
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/JsonPojoDeserializer.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/JsonPojoDeserializer.java
@@ -80,6 +80,8 @@ public final class JsonPojoDeserializer<T> implements Deserializer<T> {
         try {
             return objectMapper.readValue(bytes, tClass);
         } catch (IOException e) {
+            // FIXME This differs from AbstractJsonDeserializer, which returns null.
+            // See https://stackoverflow.com/questions/51136942/how-to-handle-serializationexception-after-deserialization
             throw new SerializationException(e);
         }
     }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MappedMetricDataJsonSerde.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MappedMetricDataJsonSerde.java
@@ -15,30 +15,30 @@
  */
 package com.expedia.adaptivealerting.kafka.serde;
 
-import com.expedia.metrics.MetricData;
+import com.expedia.adaptivealerting.core.data.MappedMetricData;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
-public class MetricDataSerde implements Serde<MetricData> {
-
+public final class MappedMetricDataJsonSerde implements Serde<MappedMetricData> {
+    
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
+    public void configure(Map<String, ?> map, boolean b) {
     }
-
+    
     @Override
     public void close() {
     }
-
+    
     @Override
-    public Serializer<MetricData> serializer() {
-        return new MetricDataSerializer();
+    public Serializer<MappedMetricData> serializer() {
+        return new MappedMetricDataJsonSerializer();
     }
-
+    
     @Override
-    public Deserializer<MetricData> deserializer() {
-        return new MetricDataDeserializer();
+    public Deserializer<MappedMetricData> deserializer() {
+        return new MappedMetricDataJsonDeserializer();
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MetricDataJsonSerde.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/serde/MetricDataJsonSerde.java
@@ -22,23 +22,23 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
-public class MetricDataSerde implements Serde<MetricData> {
-
+public final class MetricDataJsonSerde implements Serde<MetricData> {
+    
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
+    public void configure(Map<String, ?> map, boolean b) {
     }
-
+    
     @Override
     public void close() {
     }
-
+    
     @Override
     public Serializer<MetricData> serializer() {
-        return new MetricDataSerializer();
+        return new MetricDataJsonSerializer();
     }
-
+    
     @Override
     public Deserializer<MetricData> deserializer() {
-        return new MetricDataDeserializer();
+        return new MetricDataJsonDeserializer();
     }
 }

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaAnomalyToAlertMapperTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaAnomalyToAlertMapperTest.java
@@ -18,6 +18,7 @@ package com.expedia.adaptivealerting.kafka;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.adaptivealerting.core.data.MappedMetricData;
 import com.expedia.adaptivealerting.core.util.jackson.ObjectMapperUtil;
+import com.expedia.adaptivealerting.kafka.serde.MappedMetricDataJsonSerde;
 import com.expedia.adaptivealerting.kafka.util.TestObjectMother;
 import com.expedia.alertmanager.model.Alert;
 import com.expedia.metrics.MetricData;
@@ -102,7 +103,7 @@ public class KafkaAnomalyToAlertMapperTest {
 
     private void initTestMachinery() {
         val topology = new KafkaAnomalyToAlertMapper(streamsAppConfig).buildTopology();
-        this.logAndFailDriver = TestObjectMother.topologyTestDriver(topology, MappedMetricData.class, false);
+        this.logAndFailDriver = TestObjectMother.topologyTestDriver(topology, MappedMetricDataJsonSerde.class, false);
         this.mappedMetricDataFactory = TestObjectMother.mappedMetricDataFactory();
         this.stringDeserializer = new StringDeserializer();
         this.alertDeserializer = TestObjectMother.alertDeserializer();

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaAnomalyToMetricMapperTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaAnomalyToMetricMapperTest.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.kafka;
 
 import com.expedia.adaptivealerting.core.data.MappedMetricData;
 import com.expedia.adaptivealerting.core.util.jackson.ObjectMapperUtil;
+import com.expedia.adaptivealerting.kafka.serde.MappedMetricDataJsonSerde;
 import com.expedia.adaptivealerting.kafka.serde.MetricDataDeserializer;
 import com.expedia.adaptivealerting.kafka.util.TestObjectMother;
 import com.expedia.metrics.MetricData;
@@ -101,7 +102,7 @@ public class KafkaAnomalyToMetricMapperTest {
         
         // Topology test drivers
         val topology = new KafkaAnomalyToMetricMapper(saConfig).buildTopology();
-        this.logAndFailDriver = TestObjectMother.topologyTestDriver(topology, MappedMetricData.class, false);
+        this.logAndFailDriver = TestObjectMother.topologyTestDriver(topology, MappedMetricDataJsonSerde.class, false);
         
         // MappedMetricData producer
         this.mappedMetricDataFactory = TestObjectMother.mappedMetricDataFactory();


### PR DESCRIPTION
The point of the anomalies topic is to notify downstreams of anomalous
metrics, so it doesn't make sense to send non-anomalous metrics.

I've left logging non-anomalous metrics in place for now. It is unclear
whether we want to keep that (due to the volume), but that's a follow-up
discussion with the team.

In the KafkaAnomalyDetectorMapper, I replaced the JsonPojoSerde (output
value serde) with a MappedMetricDataJsonSerde, as the former is
deprecated. Behaviorally, the MMDJsonSerde returns null when
deserialization fails, instead of throwing an exception. This is in line
with the guidance here:

https://stackoverflow.com/questions/51136942/how-to-handle-serializationexception-after-deserialization

Finally, I added a few unit test cases and refactored the manager and
mapper a bit, mostly to clarify the stream processing logic in those two
components.