### PR TITLE
mc-a2m-mapper must handle tags with null values

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetector.java
@@ -20,7 +20,7 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyThresholds;
 import com.expedia.metrics.MetricData;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.UUID;
@@ -48,20 +48,22 @@ import static java.lang.Math.sqrt;
  * @see <a href="https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation">Exponentially weighted moving average and standard deviation</a>
  * @see <a href="https://www.itl.nist.gov/div898/handbook/pmc/section3/pmc324.htm">EWMA Control Charts</a>
  */
-@Data
 public final class EwmaAnomalyDetector extends AbstractAnomalyDetector<EwmaParams> {
 
+    @Getter
     @NonNull
     private EwmaParams params;
 
     /**
      * Mean estimate.
      */
+    @Getter
     private double mean = 0.0;
 
     /**
      * Variance estimate.
      */
+    @Getter
     private double variance = 0.0;
     
     public EwmaAnomalyDetector() {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyToMetricMapperTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyToMetricMapperTest.java
@@ -19,7 +19,6 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.adaptivealerting.core.util.MetricUtil;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import java.util.UUID;
 import static com.expedia.adaptivealerting.anomdetect.AnomalyToMetricMapper.AA_DETECTOR_UUID;
 import static org.junit.Assert.assertTrue;
 
-@Slf4j
 public class AnomalyToMetricMapperTest {
     private AnomalyToMetricMapper mapperUnderTest;
     private AnomalyResult anomalyResultWithStringMetricKey;

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyToMetricMapperTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/AnomalyToMetricMapperTest.java
@@ -19,6 +19,7 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.adaptivealerting.core.util.MetricUtil;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +29,7 @@ import java.util.UUID;
 import static com.expedia.adaptivealerting.anomdetect.AnomalyToMetricMapper.AA_DETECTOR_UUID;
 import static org.junit.Assert.assertTrue;
 
+@Slf4j
 public class AnomalyToMetricMapperTest {
     private AnomalyToMetricMapper mapperUnderTest;
     private AnomalyResult anomalyResultWithStringMetricKey;
@@ -39,7 +41,7 @@ public class AnomalyToMetricMapperTest {
     }
     
     @Test
-    public void testTransformWithStringMetricKey() {
+    public void toMetricDataWithStringMetricKey() {
         val actualMetric = mapperUnderTest.toMetricData(anomalyResultWithStringMetricKey);
         val actualMetricDef = actualMetric.getMetricDefinition();
         val actualTags = actualMetricDef.getTags();
@@ -51,12 +53,12 @@ public class AnomalyToMetricMapperTest {
     }
     
     @Test(expected = IllegalArgumentException.class)
-    public void testTransformRejectsNullAnomalyResult() {
+    public void toMetricDataRejectsNullAnomalyResult() {
         mapperUnderTest.toMetricData(null);
     }
     
     @Test(expected = IllegalArgumentException.class)
-    public void testTransformRejectsDetectorUuidTag() {
+    public void toMetricDataRejectsAADetectorUuidTag() {
         val kvTags = MetricUtil.defaultKvTags();
         kvTags.put(AA_DETECTOR_UUID, UUID.randomUUID().toString());
         
@@ -66,7 +68,7 @@ public class AnomalyToMetricMapperTest {
         
         mapperUnderTest.toMetricData(anomResult);
     }
-    
+
     private void initTestObjects() {
         val metricDef = new MetricDefinition("someKey");
         val metricData = MetricUtil.metricData(metricDef);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaTestRow.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaTestRow.java
@@ -25,7 +25,7 @@ public class EwmaTestRow {
     private String date;
     
     @CsvBindByName
-    private int observed;
+    private double observed;
     
     @CsvBindByName
     private double mean;

--- a/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricUtil.java
+++ b/core/src/main/java/com/expedia/adaptivealerting/core/util/MetricUtil.java
@@ -15,21 +15,16 @@
  */
 package com.expedia.adaptivealerting.core.util;
 
-import com.expedia.adaptivealerting.core.data.MetricFrame;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
 import com.expedia.metrics.TagCollection;
 import lombok.val;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 
 /**
  * Metric utilities.
@@ -91,21 +86,5 @@ public final class MetricUtil {
      */
     public static MetricData metricData(MetricDefinition metricDef, double value) {
         return new MetricData(metricDef, value, Instant.now().getEpochSecond());
-    }
-    
-    public static MetricFrame merge(List<MetricFrame> frames) {
-        notNull(frames, "frames can't be null");
-        
-        int totalSize = 0;
-        for (final MetricFrame frame : frames) {
-            totalSize += frame.getNumRows();
-        }
-        
-        final List<MetricData> resultList = new ArrayList<>(totalSize);
-        for (final MetricFrame frame : frames) {
-            resultList.addAll(frame.getMetricData());
-        }
-        
-        return new MetricFrame(resultList);
     }
 }

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMultiClusterAnomalyToMetricMapper.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMultiClusterAnomalyToMetricMapper.java
@@ -61,24 +61,26 @@ public class KafkaMultiClusterAnomalyToMetricMapper implements Runnable {
     private String metricTopic;
     
     public static void main(String[] args) {
-        
+        buildKafkaMultiClusterAnomalyToMetricMapper().run();
+    }
+
+    static KafkaMultiClusterAnomalyToMetricMapper buildKafkaMultiClusterAnomalyToMetricMapper() {
         // TODO Refactor the loader such that it's not tied to Kafka Streams. [WLW]
         val config = new TypesafeConfigLoader(APP_ID).loadMergedConfig();
-        
+
         val consumerConfig = config.getConfig(ANOMALY_CONSUMER);
         val consumerTopic = consumerConfig.getString(TOPIC);
         val consumerProps = ConfigUtil.toConsumerConfig(consumerConfig);
         val consumer = new KafkaConsumer<String, MappedMetricData>(consumerProps);
-        
+
         val producerConfig = config.getConfig(METRIC_PRODUCER);
         val producerTopic = producerConfig.getString(TOPIC);
         val producerProps = ConfigUtil.toProducerConfig(producerConfig);
         val producer = new KafkaProducer<String, MetricData>(producerProps);
-        
-        val mapper = new KafkaMultiClusterAnomalyToMetricMapper(consumer, producer, consumerTopic, producerTopic);
-        mapper.run();
+
+        return new KafkaMultiClusterAnomalyToMetricMapper(consumer, producer, consumerTopic, producerTopic);
     }
-    
+
     public KafkaMultiClusterAnomalyToMetricMapper(
             Consumer<String, MappedMetricData> anomalyConsumer,
             Producer<String, MetricData> metricProducer,

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMultiClusterAnomalyToMetricMapper.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMultiClusterAnomalyToMetricMapper.java
@@ -61,10 +61,6 @@ public class KafkaMultiClusterAnomalyToMetricMapper implements Runnable {
     private String metricTopic;
     
     public static void main(String[] args) {
-        buildKafkaMultiClusterAnomalyToMetricMapper().run();
-    }
-
-    static KafkaMultiClusterAnomalyToMetricMapper buildKafkaMultiClusterAnomalyToMetricMapper() {
         // TODO Refactor the loader such that it's not tied to Kafka Streams. [WLW]
         val config = new TypesafeConfigLoader(APP_ID).loadMergedConfig();
 
@@ -78,7 +74,8 @@ public class KafkaMultiClusterAnomalyToMetricMapper implements Runnable {
         val producerProps = ConfigUtil.toProducerConfig(producerConfig);
         val producer = new KafkaProducer<String, MetricData>(producerProps);
 
-        return new KafkaMultiClusterAnomalyToMetricMapper(consumer, producer, consumerTopic, producerTopic);
+        val mapper = new KafkaMultiClusterAnomalyToMetricMapper(consumer, producer, consumerTopic, producerTopic);
+        mapper.run();
     }
 
     public KafkaMultiClusterAnomalyToMetricMapper(

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
@@ -37,7 +37,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static com.expedia.adaptivealerting.kafka.KafkaMultiClusterAnomalyToMetricMapper.buildKafkaMultiClusterAnomalyToMetricMapper;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * {@link KafkaMultiClusterAnomalyToMetricMapper} unit test.
@@ -84,9 +86,18 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
-    
+
     @Test
-    public void run() throws Exception {
+    public void testBuildKafkaMultiClusterAnomalyToMetricMapper() {
+        // This is its own method for code coverage.
+        val mapper = buildKafkaMultiClusterAnomalyToMetricMapper();
+        assertNotNull(mapper);
+        assertNotNull(mapper.getAnomalyConsumer());
+        assertNotNull(mapper.getMetricProducer());
+    }
+
+    @Test
+    public void testRun() throws Exception {
         
         // TODO This mapped metric data represents an anomaly. It's a little confusing because there's a class called
         // AnomalyResult, which seems more like an anomaly. Want to revisit whether we need to put the whole MMD on the
@@ -113,13 +124,13 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
     }
 
     @Test
-    public void runSkipsAnomaliesWithAADetectorUuid() throws Exception {
+    public void testRunSkipsAnomaliesWithAADetectorUuid() throws Exception {
         val invalidAnomaly = TestObjectMother.mappedMetricDataWithAnomalyResultAndAADetectorUuid();
         runSkipsInvalidAnomalies(invalidAnomaly);
     }
 
     @Test
-    public void runSkipsAnomaliesHavingTagWithNullValue() throws Exception {
+    public void testRunSkipsAnomaliesHavingTagWithNullValue() throws Exception {
         val invalidAnomaly = TestObjectMother.mappedMetricDataWithAnomalyResultAndNullTagValue();
         runSkipsInvalidAnomalies(invalidAnomaly);
     }

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
@@ -37,9 +37,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static com.expedia.adaptivealerting.kafka.KafkaMultiClusterAnomalyToMetricMapper.buildKafkaMultiClusterAnomalyToMetricMapper;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * {@link KafkaMultiClusterAnomalyToMetricMapper} unit test.
@@ -85,15 +83,6 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
                 .registerModule(new MetricsJavaModule())
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
-
-    @Test
-    public void testBuildKafkaMultiClusterAnomalyToMetricMapper() {
-        // This is its own method for code coverage.
-        val mapper = buildKafkaMultiClusterAnomalyToMetricMapper();
-        assertNotNull(mapper);
-        assertNotNull(mapper.getAnomalyConsumer());
-        assertNotNull(mapper.getMetricProducer());
     }
 
     @Test

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMultiClusterAnomalyToMetricMapperTest.java
@@ -85,7 +85,7 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
     }
     
     @Test
-    public void testRun() throws Exception {
+    public void run() throws Exception {
         
         // TODO This mapped metric data represents an anomaly. It's a little confusing because there's a class called
         // AnomalyResult, which seems more like an anomaly. Want to revisit whether we need to put the whole MMD on the
@@ -112,7 +112,7 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
     }
 
     @Test
-    public void testRunSkipsAnomaliesWithDetectorUuid() throws Exception {
+    public void runSkipsAnomaliesWithAADetectorUuid() throws Exception {
         val tagsWithDetectorUuid = TestObjectMother.metricTagsWithDetectorUuid();
         val metricDefWithDetectorUuid = new MetricDefinition("some-metric-key", tagsWithDetectorUuid, TagCollection.EMPTY);
         val metricDataWithDetectorUuid = TestObjectMother.metricData(metricDefWithDetectorUuid, 100.0);
@@ -165,6 +165,11 @@ public class KafkaMultiClusterAnomalyToMetricMapperTest {
         for (val metric : metrics) {
             log.info("metric={}", metric);
         }
+    }
+
+    @Test
+    public void runSkipsAnomaliesHavingTagWithNullValue() {
+        // TODO Do this after improving runSkipsAnomaliesWithAADetectorUuid()
     }
 
     private KafkaConsumer<String, MappedMetricData> buildAnomalyConsumer() {

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/util/TestObjectMother.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/util/TestObjectMother.java
@@ -77,13 +77,23 @@ public final class TestObjectMother {
         return new TagCollection(tags);
     }
 
-    public static TagCollection metricTagsWithDetectorUuid() {
+    public static TagCollection metricTagsWithAADetectorUuid() {
         val tags = new HashMap<String, String>();
         tags.put("mtype", "gauge");
         tags.put("unit", "");
         tags.put("org_id", "1");
         tags.put("interval", "1");
         tags.put(AnomalyToMetricMapper.AA_DETECTOR_UUID, UUID.randomUUID().toString());
+        return new TagCollection(tags);
+    }
+
+    public static TagCollection metricTagsWithNullTagValue() {
+        val tags = new HashMap<String, String>();
+        tags.put("mtype", "gauge");
+        tags.put("unit", "");
+        tags.put("org_id", "1");
+        tags.put("interval", "1");
+        tags.put("some-tag-key", null);
         return new TagCollection(tags);
     }
 
@@ -135,7 +145,21 @@ public final class TestObjectMother {
         mmd.setAnomalyResult(anomalyResult(metricData));
         return mmd;
     }
-    
+
+    public static MappedMetricData mappedMetricDataWithAnomalyResultAndAADetectorUuid() {
+        val tags = metricTagsWithAADetectorUuid();
+        val metricDef = new MetricDefinition("some-metric-key", tags, TagCollection.EMPTY);
+        val metricData = metricData(metricDef, 100.0);
+        return mappedMetricDataWithAnomalyResult(metricData);
+    }
+
+    public static MappedMetricData mappedMetricDataWithAnomalyResultAndNullTagValue() {
+        val tags = metricTagsWithNullTagValue();
+        val metricDef = new MetricDefinition("some-metric-key", tags, TagCollection.EMPTY);
+        val metricData = metricData(metricDef, 100.0);
+        return mappedMetricDataWithAnomalyResult(metricData);
+    }
+
     public static AnomalyResult anomalyResult(MetricData metricData) {
         return anomalyResult(metricData, AnomalyLevel.STRONG);
     }


### PR DESCRIPTION
In production we see metrics with null tag values, for whatever reason.
Metricstank and Metrics 2.0 don't support this, so currently such metrics
generate IllegalArgumentExceptions and the mapper gets stuck on them.

This commit catches the IllegalArgumentException and responds by returning
null for offending metrics.