### PR TITLE
Refactoring to simplify detector initialization

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorParams.java
@@ -13,25 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect.util;
+package com.expedia.adaptivealerting.anomdetect;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public interface DetectorParams {
 
-import java.sql.Timestamp;
-import java.util.Map;
-import java.util.UUID;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ModelResource {
-    private Long id;
-    private UUID uuid;
-    private ModelTypeResource detectorType;
-    private Map<String, Object> params;
-    private Timestamp dateCreated;
+    void validate();
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdAnomalyDetector.java
@@ -16,15 +16,10 @@
 package com.expedia.adaptivealerting.anomdetect.constant;
 
 import com.expedia.adaptivealerting.anomdetect.AbstractAnomalyDetector;
-import com.expedia.adaptivealerting.core.anomaly.AnomalyLevel;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
-import com.expedia.adaptivealerting.core.anomaly.AnomalyThresholds;
-import com.expedia.adaptivealerting.core.anomaly.AnomalyType;
 import com.expedia.metrics.MetricData;
 import lombok.Data;
-import lombok.NonNull;
-
-import java.util.UUID;
+import lombok.val;
 
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 
@@ -34,41 +29,17 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 @Data
 public final class ConstantThresholdAnomalyDetector extends AbstractAnomalyDetector<ConstantThresholdParams> {
 
-    @NonNull
-    private ConstantThresholdParams params;
-
     public ConstantThresholdAnomalyDetector() {
-        this(UUID.randomUUID(), new ConstantThresholdParams());
-    }
-
-    public ConstantThresholdAnomalyDetector(ConstantThresholdParams params) {
-        this(UUID.randomUUID(), params);
-    }
-
-    public ConstantThresholdAnomalyDetector(UUID uuid, ConstantThresholdParams params) {
-        notNull(uuid, "uuid can't be null");
-        notNull(params, "params can't be null");
-
-        setUuid(uuid);
-        loadParams(params);
-    }
-
-    @Override
-    protected Class<ConstantThresholdParams> getParamsClass() {
-        return ConstantThresholdParams.class;
-    }
-
-    @Override
-    protected void loadParams(ConstantThresholdParams params) {
-        this.params = params;
+        super(ConstantThresholdParams.class);
     }
 
     @Override
     public AnomalyResult classify(MetricData metricData) {
         notNull(metricData, "metricData can't be null");
-        final AnomalyThresholds thresholds = params.getThresholds();
-        final AnomalyType type = params.getType();
-        final AnomalyLevel level = thresholds.classify(type, metricData.getValue());
+        val params = getParams();
+        val thresholds = params.getThresholds();
+        val type = params.getType();
+        val level = thresholds.classify(type, metricData.getValue());
         return new AnomalyResult(getUuid(), metricData, level);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdParams.java
@@ -15,6 +15,7 @@
  */
 package com.expedia.adaptivealerting.anomdetect.constant;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyThresholds;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyType;
 import lombok.Data;
@@ -22,7 +23,7 @@ import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
-public class ConstantThresholdParams {
+public class ConstantThresholdParams implements DetectorParams {
 
     /**
      * Detector type: left-, right- or two-tailed.
@@ -31,4 +32,8 @@ public class ConstantThresholdParams {
     
     private AnomalyThresholds thresholds;
 
+    @Override
+    public void validate() {
+        // Not currently implemented
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumParams.java
@@ -15,13 +15,14 @@
  */
 package com.expedia.adaptivealerting.anomdetect.cusum;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyType;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
-public final class CusumParams {
+public final class CusumParams implements DetectorParams {
 
     /**
      * Detector type: left-, right- or two-tailed.
@@ -57,4 +58,9 @@ public final class CusumParams {
      * Minimum number of data points required before this anomaly detector is available for use.
      */
     private int warmUpPeriod = 25;
+
+    @Override
+    public void validate() {
+        // Not currently implemented
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaParams.java
@@ -15,6 +15,7 @@
  */
 package com.expedia.adaptivealerting.anomdetect.ewma;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -22,7 +23,7 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.isTrue;
 
 @Data
 @Accessors(chain = true)
-public final class EwmaParams {
+public final class EwmaParams implements DetectorParams {
     
     /**
      * Smoothing param. Somewhat misnamed because higher values lead to less smoothing, but it's called the
@@ -44,7 +45,8 @@ public final class EwmaParams {
      * Initial mean estimate.
      */
     private double initMeanEstimate = 0.0;
-    
+
+    @Override
     public void validate() {
         isTrue(0.0 <= alpha && alpha <= 1.0, "Required: alpha in the range [0, 1]");
         isTrue(weakSigmas > 0.0, "Required: weakSigmas > 0.0");

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersAnomalyDetector.java
@@ -23,8 +23,7 @@ import com.expedia.metrics.MetricData;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-
-import java.util.UUID;
+import lombok.val;
 
 import static com.expedia.adaptivealerting.core.anomaly.AnomalyLevel.MODEL_WARMUP;
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
@@ -40,8 +39,6 @@ import static java.lang.String.format;
 public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<HoltWintersParams> {
 
     @NonNull
-    private HoltWintersParams params;
-    @NonNull
     private HoltWintersOnlineComponents components;
     @NonNull
     private HoltWintersSimpleTrainingModel holtWintersSimpleTrainingModel;
@@ -49,39 +46,16 @@ public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<Ho
     private HoltWintersOnlineAlgorithm holtWintersOnlineAlgorithm;
 
     public HoltWintersAnomalyDetector() {
-        this(UUID.randomUUID(), new HoltWintersParams());
+        super(HoltWintersParams.class);
     }
 
-    public HoltWintersAnomalyDetector(HoltWintersParams params) {
-        this(UUID.randomUUID(), params);
-    }
-
-    public HoltWintersAnomalyDetector(UUID uuid, HoltWintersParams params) {
-        notNull(uuid, "uuid can't be null");
-        notNull(params, "params can't be null");
-
-        // We used to have a params.validate() call here, but that broke the noargs constructor above since
-        // HoltWintersParams starts life with an invalid frequency=0. We may want to remove all the constructors other
-        // than the noargs constructors. [WLW]
-
-        setUuid(uuid);
-        loadParams(params);
+    @Override
+    protected void initState(HoltWintersParams params) {
         components = new HoltWintersOnlineComponents(params);
         holtWintersOnlineAlgorithm = new HoltWintersOnlineAlgorithm();
         holtWintersSimpleTrainingModel = new HoltWintersSimpleTrainingModel(params);
         double initForecast = holtWintersOnlineAlgorithm.getForecast(params.getSeasonalityType(), components.getLevel(), components.getBase(), components.getSeasonal(components.getCurrentSeasonalIndex()));
         components.setForecast(initForecast);
-    }
-
-    @Override
-    protected void loadParams(HoltWintersParams params) {
-        params.validate();
-        this.params = params;
-    }
-
-    @Override
-    protected Class<HoltWintersParams> getParamsClass() {
-        return HoltWintersParams.class;
     }
 
     @Override
@@ -97,6 +71,7 @@ public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<Ho
     }
 
     private void trainOrObserve(double observed) {
+        val params = getParams();
         if (!isInitialTrainingComplete()) {
             holtWintersSimpleTrainingModel.observeAndTrain(observed, params, components);
         } else {
@@ -105,6 +80,7 @@ public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<Ho
     }
 
     public boolean isInitialTrainingComplete() {
+        val params = getParams();
         switch (params.getInitTrainingMethod()) {
             case NONE: return true;
             case SIMPLE: return holtWintersSimpleTrainingModel.isTrainingComplete(params);
@@ -132,6 +108,7 @@ public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<Ho
      */
     private AnomalyThresholds buildAnomalyThresholds(double prevForecast) {
         // TODO HW: Look at options for configuring how bands are defined
+        val params = getParams();
         double stddev = components.getSeasonalStandardDeviation(components.getCurrentSeasonalIndex());
         final double weakDelta = params.getWeakSigmas() * stddev;
         final double strongDelta = params.getStrongSigmas() * stddev;
@@ -144,6 +121,7 @@ public final class HoltWintersAnomalyDetector extends AbstractAnomalyDetector<Ho
     }
 
     private boolean stillWarmingUp() {
+        val params = getParams();
         return components.getN() <= params.getWarmUpPeriod();
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersParams.java
@@ -15,6 +15,7 @@
  */
 package com.expedia.adaptivealerting.anomdetect.holtwinters;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,8 @@ import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
 @Data
 @Accessors(chain = true)
 @Slf4j
-public final class HoltWintersParams {
+public final class HoltWintersParams implements DetectorParams {
+
     /**
      * SeasonalityType parameter used to determine which Seasonality method (Multiplicative or Additive) to use.
      */
@@ -128,6 +130,7 @@ public final class HoltWintersParams {
         return (initTrainingMethod == SIMPLE) ? (frequency * 2) : 0;
     }
 
+    @Override
     public void validate() {
         notNull(seasonalityType, "Required: seasonalityType one of " + Arrays.toString(SeasonalityType.values()));
         notNull(initTrainingMethod, "Required: initTrainingMethod one of " + Arrays.toString(HoltWintersTrainingMethod.values()));

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsControlChartAnomalyDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsControlChartAnomalyDetector.java
@@ -21,9 +21,7 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyThresholds;
 import com.expedia.metrics.MetricData;
 import lombok.Data;
-import lombok.NonNull;
-
-import java.util.UUID;
+import lombok.val;
 
 import static com.expedia.adaptivealerting.core.anomaly.AnomalyLevel.*;
 import static com.expedia.adaptivealerting.core.util.AssertUtil.notNull;
@@ -43,17 +41,10 @@ public final class IndividualsControlChartAnomalyDetector extends AbstractAnomal
     private static final double R_CONTROL_CHART_CONSTANT_D4 = 3.267;
     private static final double R_CONTROL_CHART_CONSTANT_D2 = 1.128;
 
-
     /**
      * Number of points after which limits will be recomputed
      */
     private static final int RECOMPUTE_LIMITS_PERIOD = 100;
-
-    @NonNull
-    private UUID uuid;
-
-    @NonNull
-    private IndividualsControlChartParams params;
 
     /**
      * Aggregate Moving range. Used to calculate avg. moving range.
@@ -101,52 +92,30 @@ public final class IndividualsControlChartAnomalyDetector extends AbstractAnomal
     private double mean;
 
     public IndividualsControlChartAnomalyDetector() {
-        this(UUID.randomUUID(), new IndividualsControlChartParams());
+        super(IndividualsControlChartParams.class);
     }
 
-    public IndividualsControlChartAnomalyDetector(IndividualsControlChartParams params) {
-        this(UUID.randomUUID(),params);
-    }
-
-    /**
-     * Creates a new detector. Initial target is given by params.initValue and initial variance is 0.
-     *
-     * @param uuid   Detector UUID.
-     * @param params Model params.
-     */
-    public IndividualsControlChartAnomalyDetector(UUID uuid, IndividualsControlChartParams params) {
-        notNull(uuid, "uuid can't be null");
-        notNull(params, "params can't be null");
-
-        this.uuid = uuid;
-        this.params = params;
+    @Override
+    protected void initState(IndividualsControlChartParams params) {
         this.prevValue = params.getInitValue();
         this.target = params.getInitValue();
-    }
-
-    @Override
-    protected void loadParams(IndividualsControlChartParams params) {
-        this.params = params;
         this.mean = params.getInitMeanEstimate();
-    }
-
-    @Override
-    protected Class<IndividualsControlChartParams> getParamsClass() {
-        return IndividualsControlChartParams.class;
     }
 
     @Override
     public AnomalyResult classify(MetricData metricData) {
         notNull(metricData, "metricData can't be null");
 
-        final double observed = metricData.getValue();
-        final double stdDev = sqrt(this.variance);
-        //final double weakDelta = params.getWeakSigmas() * stdDev;
-        final double strongDelta = params.getStrongSigmas() * stdDev;
+        val params = getParams();
 
-        double currentRange = Math.abs(prevValue - observed);
+        val observed = metricData.getValue();
+        val stdDev = sqrt(this.variance);
+//        val weakDelta = params.getWeakSigmas() * stdDev;
+        val strongDelta = params.getStrongSigmas() * stdDev;
 
-        final AnomalyThresholds thresholds = new AnomalyThresholds(
+        val currentRange = Math.abs(prevValue - observed);
+
+        val thresholds = new AnomalyThresholds(
                 this.mean + strongDelta,
                 this.mean + strongDelta,
                 this.mean - strongDelta,

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsControlChartParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsControlChartParams.java
@@ -15,12 +15,13 @@
  */
 package com.expedia.adaptivealerting.anomdetect.individuals;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
-public final class IndividualsControlChartParams {
+public final class IndividualsControlChartParams implements DetectorParams {
     
     /**
      * Initial mean estimate.
@@ -41,4 +42,9 @@ public final class IndividualsControlChartParams {
      * Initial mean estimate.
      */
     private double initMeanEstimate = 0.0;
+
+    @Override
+    public void validate() {
+        // Not currently implemented
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/pewma/PewmaParams.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/pewma/PewmaParams.java
@@ -15,12 +15,13 @@
  */
 package com.expedia.adaptivealerting.anomdetect.pewma;
 
+import com.expedia.adaptivealerting.anomdetect.DetectorParams;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
-public final class PewmaParams {
+public final class PewmaParams implements DetectorParams {
     
     /**
      * Smoothing param.
@@ -51,4 +52,9 @@ public final class PewmaParams {
      * How many iterations to train for.
      */
     private final int warmUpPeriod = 30;
+
+    @Override
+    public void validate() {
+        // Not currently implemented
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/TempHaystackAwareDetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/TempHaystackAwareDetectorSource.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.anomdetect.source;
 
 import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
+import com.expedia.adaptivealerting.anomdetect.ewma.EwmaParams;
 import com.expedia.adaptivealerting.anomdetect.util.DetectorMeta;
 import com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector;
 import com.expedia.metrics.MetricDefinition;
@@ -105,7 +106,8 @@ public final class TempHaystackAwareDetectorSource implements DetectorSource {
     private AnomalyDetector createHaystackDetector(UUID detectorUuid) {
         AnomalyDetector detector = haystackDetectorMap.get(detectorUuid);
         if (detector == null) {
-            detector = new EwmaAnomalyDetector(detectorUuid);
+            detector = new EwmaAnomalyDetector();
+            ((EwmaAnomalyDetector) detector).init(detectorUuid, new EwmaParams());
             haystackDetectorMap.put(detectorUuid, detector);
         }
         return detector;

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/constant/ConstantThresholdAnomalyDetectorTest.java
@@ -21,6 +21,7 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyThresholds;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyType;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
+import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -99,9 +100,13 @@ public class ConstantThresholdAnomalyDetectorTest {
     }
 
     private ConstantThresholdAnomalyDetector detector(UUID uuid, AnomalyThresholds thresholds, AnomalyType type) {
-        ConstantThresholdParams params = new ConstantThresholdParams()
-                .setThresholds(thresholds).setType(type);
-        return new ConstantThresholdAnomalyDetector(uuid, params);
+        val params = new ConstantThresholdParams()
+                .setThresholds(thresholds)
+                .setType(type);
+
+        val detector = new ConstantThresholdAnomalyDetector();
+        detector.init(uuid, params);
+        return detector;
     }
 
     private AnomalyLevel classify(AnomalyDetector detector, long epochSecond, float value) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/cusum/CusumAnomalyDetectorTest.java
@@ -22,6 +22,7 @@ import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
 import com.opencsv.bean.CsvToBeanBuilder;
 import junit.framework.TestCase;
+import lombok.val;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,7 +31,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
@@ -60,10 +60,10 @@ public class CusumAnomalyDetectorTest {
     
     @Test
     public void testEvaluate() {
-        final ListIterator<CusumTestRow> testRows = data.listIterator();
-        final CusumTestRow testRow0 = testRows.next();
+        val testRows = data.listIterator();
+        val testRow0 = testRows.next();
         
-        final CusumParams params = new CusumParams()
+        val params = new CusumParams()
                 .setType(AnomalyType.RIGHT_TAILED)
                 .setTargetValue(0.16)
                 .setWeakSigmas(WEAK_SIGMAS)
@@ -71,8 +71,10 @@ public class CusumAnomalyDetectorTest {
                 .setSlackParam(0.5)
                 .setInitMeanEstimate(testRow0.getObserved())
                 .setWarmUpPeriod(WARMUP_PERIOD);
-        final CusumAnomalyDetector detector = new CusumAnomalyDetector(detectorUUID, params);
-        
+
+        val detector = new CusumAnomalyDetector();
+        detector.init(detectorUUID, params);
+
         int numDataPoints = 1;
     
         while (testRows.hasNext()) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/ewma/EwmaAnomalyDetectorTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -50,17 +51,18 @@ public class EwmaAnomalyDetectorTest {
         this.epochSecond = Instant.now().getEpochSecond();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_alphaOutOfRange() {
-        new EwmaAnomalyDetector(new EwmaParams().setAlpha(2.0));
-    }
-
     @Test
-    public void noArgConstructor() {
+    public void testInit() {
         val detector = new EwmaAnomalyDetector();
+        detector.init(UUID.randomUUID(), new EwmaParams());
         assertNotNull(detector.getUuid());
         assertNotNull(detector.getParams());
         assertEquals(EwmaParams.class, detector.getParamsClass());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInit_alphaOutOfRange() {
+        new EwmaAnomalyDetector().init(UUID.randomUUID(), new EwmaParams().setAlpha(2.0));
     }
 
     @Test
@@ -72,7 +74,8 @@ public class EwmaAnomalyDetectorTest {
         val params = new EwmaParams()
                 .setAlpha(0.05)
                 .setInitMeanEstimate(observed0);
-        val detector = new EwmaAnomalyDetector(params);
+        val detector = new EwmaAnomalyDetector();
+        detector.init(UUID.randomUUID(), params);
 
         assertEquals(observed0, detector.getMean());
         assertEquals(0.0, detector.getVariance());

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/holtwinters/HoltWintersAnomalyDetectorTest.java
@@ -18,6 +18,7 @@ package com.expedia.adaptivealerting.anomdetect.holtwinters;
 import com.expedia.adaptivealerting.core.anomaly.AnomalyResult;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
+import lombok.val;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,10 +29,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.UUID;
 
-import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAustouristsTestHelper.AUSTOURISTS_ADD_DATA;
-import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAustouristsTestHelper.AUSTOURISTS_MULT_DATA;
-import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAustouristsTestHelper.TOLERANCE;
-import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAustouristsTestHelper.buildAustouristsParams;
+import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersAustouristsTestHelper.*;
 import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersTrainingMethod.SIMPLE;
 import static com.expedia.adaptivealerting.anomdetect.holtwinters.SeasonalityType.ADDITIVE;
 import static com.expedia.adaptivealerting.anomdetect.holtwinters.SeasonalityType.MULTIPLICATIVE;
@@ -57,11 +55,12 @@ public class HoltWintersAnomalyDetectorTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_alphaOutOfRange() {
-        final HoltWintersParams params = new HoltWintersParams()
+    public void testInit_alphaOutOfRange() {
+        val params = new HoltWintersParams()
                 .setFrequency(24)
                 .setAlpha(2.0);
-        new HoltWintersAnomalyDetector(detectorUUID, params);
+        val detector = new HoltWintersAnomalyDetector();
+        detector.init(detectorUUID, params);
     }
 
     @Test
@@ -93,7 +92,9 @@ public class HoltWintersAnomalyDetectorTest {
         final HoltWintersParams params = withTraining ?
                 buildAustouristsParams(seasonalityType).setInitTrainingMethod(SIMPLE) :
                 buildAustouristsParams(seasonalityType, initLevelEstimate, initBaseEstimate, initSeasonalEstimates);
-        final HoltWintersAnomalyDetector subject = new HoltWintersAnomalyDetector(detectorUUID, params);
+
+        val subject = new HoltWintersAnomalyDetector();
+        subject.init(detectorUUID, params);
 
         while (testRows.hasNext()) {
             final HoltWintersAustouristsTestRow testRow = testRows.next();

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsChartAnomalyDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/individuals/IndividualsChartAnomalyDetectorTest.java
@@ -21,6 +21,7 @@ import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
 import com.opencsv.bean.CsvToBeanBuilder;
 import junit.framework.TestCase;
+import lombok.val;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +30,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
@@ -60,14 +60,15 @@ public class IndividualsChartAnomalyDetectorTest {
     
     @Test
     public void testEvaluate() {
-        final ListIterator<IndividualsChartTestRow> testRows = data.listIterator();
-        final IndividualsChartTestRow testRow0 = testRows.next();
-        final double observed0 = testRow0.getObserved();
+        val testRows = data.listIterator();
+        val testRow0 = testRows.next();
+        val observed0 = testRow0.getObserved();
         
-        final IndividualsControlChartParams params = new IndividualsControlChartParams()
+        val params = new IndividualsControlChartParams()
                 .setInitValue(observed0)
                 .setWarmUpPeriod(WARMUP_PERIOD);
-        final IndividualsControlChartAnomalyDetector detector = new IndividualsControlChartAnomalyDetector(detectorUUID, params);
+        val detector = new IndividualsControlChartAnomalyDetector();
+        detector.init(detectorUUID, params);
         
         int noOfDataPoints = 1;
         

--- a/samples/src/main/java/com/expedia/adaptivealerting/samples/CsvTrafficHoltWintersVariants.java
+++ b/samples/src/main/java/com/expedia/adaptivealerting/samples/CsvTrafficHoltWintersVariants.java
@@ -24,12 +24,14 @@ import com.expedia.adaptivealerting.tools.pipeline.filter.EvaluatorFilter;
 import com.expedia.adaptivealerting.tools.pipeline.sink.AnomalyChartSink;
 import com.expedia.adaptivealerting.tools.pipeline.source.MetricFrameMetricSource;
 import com.expedia.adaptivealerting.tools.pipeline.util.PipelineFactory;
+import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jfree.chart.JFreeChart;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static com.expedia.adaptivealerting.anomdetect.holtwinters.HoltWintersTrainingMethod.SIMPLE;
 import static com.expedia.adaptivealerting.anomdetect.holtwinters.SeasonalityType.ADDITIVE;
@@ -134,7 +136,11 @@ public class CsvTrafficHoltWintersVariants {
 
     private static AnomalyChartSink buildChart(MetricFrameMetricSource source, SeasonalityType seasonalityType, HoltWintersParams params,
                                                double alpha, double beta, double gammaLow, String... titleSuffix) {
-        final AnomalyDetectorFilter adf = new AnomalyDetectorFilter(new HoltWintersAnomalyDetector(params));
+
+        val detector = new HoltWintersAnomalyDetector();
+        detector.init(UUID.randomUUID(), params);
+
+        final AnomalyDetectorFilter adf = new AnomalyDetectorFilter(detector);
         final EvaluatorFilter eval = new EvaluatorFilter(new RmseEvaluator());
         final AnomalyChartSink chartSink = PipelineFactory.createChartSink(String.format("HoltWinters %s: alpha=%s, beta=%s, gamma=%s %s", seasonalityType,
                 alpha, beta, gammaLow, Arrays.asList(titleSuffix)));

--- a/samples/src/main/java/com/expedia/adaptivealerting/samples/CsvTrafficPewmaVariants.java
+++ b/samples/src/main/java/com/expedia/adaptivealerting/samples/CsvTrafficPewmaVariants.java
@@ -22,12 +22,13 @@ import com.expedia.adaptivealerting.core.data.io.MetricFrameLoader;
 import com.expedia.adaptivealerting.core.evaluator.RmseEvaluator;
 import com.expedia.adaptivealerting.tools.pipeline.filter.AnomalyDetectorFilter;
 import com.expedia.adaptivealerting.tools.pipeline.filter.EvaluatorFilter;
-import com.expedia.adaptivealerting.tools.pipeline.sink.AnomalyChartSink;
 import com.expedia.adaptivealerting.tools.pipeline.source.MetricFrameMetricSource;
 import com.expedia.adaptivealerting.tools.pipeline.util.PipelineFactory;
 import com.expedia.metrics.MetricDefinition;
+import lombok.val;
 
 import java.io.InputStream;
+import java.util.UUID;
 
 import static com.expedia.adaptivealerting.tools.visualization.ChartUtil.createChartFrame;
 import static com.expedia.adaptivealerting.tools.visualization.ChartUtil.showChartFrame;
@@ -41,49 +42,53 @@ public class CsvTrafficPewmaVariants {
         final MetricFrame frame = MetricFrameLoader.loadCsv(new MetricDefinition("csv"), is, true);
         final MetricFrameMetricSource source = new MetricFrameMetricSource(frame, "data", 200L);
         
-        final PewmaParams params1 = new PewmaParams()
+        val params1 = new PewmaParams()
                 .setAlpha(0.15)
                 .setBeta(1.0)
                 .setWeakSigmas(2.0)
                 .setStrongSigmas(3.0)
                 .setInitMeanEstimate(0.0);
-        final AnomalyDetectorFilter ad1 = new AnomalyDetectorFilter(new PewmaAnomalyDetector(params1));
+        val detector1 = new PewmaAnomalyDetector();
+        detector1.init(UUID.randomUUID(), params1);
+        val detectorFilter1 = new AnomalyDetectorFilter(detector1);
     
-        final PewmaParams params2 = new PewmaParams()
+        val params2 = new PewmaParams()
                 .setAlpha(0.25)
                 .setBeta(1.0)
                 .setWeakSigmas(2.0)
                 .setStrongSigmas(3.0)
                 .setInitMeanEstimate(0.0);
-        final AnomalyDetectorFilter ad2 = new AnomalyDetectorFilter(new PewmaAnomalyDetector(params2));
+        val detector2 = new PewmaAnomalyDetector();
+        val detectorFilter2 = new AnomalyDetectorFilter(detector2);
     
-        final PewmaParams params3 = new PewmaParams()
+        val params3 = new PewmaParams()
                 .setAlpha(0.35)
                 .setBeta(1.0)
                 .setWeakSigmas(2.0)
                 .setStrongSigmas(3.0)
                 .setInitMeanEstimate(0.0);
-        final AnomalyDetectorFilter ad3 = new AnomalyDetectorFilter(new PewmaAnomalyDetector(params3));
-    
-        final EvaluatorFilter eval1 = new EvaluatorFilter(new RmseEvaluator());
-        final EvaluatorFilter eval2 = new EvaluatorFilter(new RmseEvaluator());
-        final EvaluatorFilter eval3 = new EvaluatorFilter(new RmseEvaluator());
+        val detector3 = new PewmaAnomalyDetector();
+        val detectorFilter3 = new AnomalyDetectorFilter(detector3);
+
+        val eval1 = new EvaluatorFilter(new RmseEvaluator());
+        val eval2 = new EvaluatorFilter(new RmseEvaluator());
+        val eval3 = new EvaluatorFilter(new RmseEvaluator());
         
-        final AnomalyChartSink chart1 = PipelineFactory.createChartSink("PEWMA: alpha=0.15");
-        final AnomalyChartSink chart2 = PipelineFactory.createChartSink("PEWMA: alpha=0.25");
-        final AnomalyChartSink chart3 = PipelineFactory.createChartSink("PEWMA: alpha=0.35");
+        val chart1 = PipelineFactory.createChartSink("PEWMA: alpha=0.15");
+        val chart2 = PipelineFactory.createChartSink("PEWMA: alpha=0.25");
+        val chart3 = PipelineFactory.createChartSink("PEWMA: alpha=0.35");
     
-        source.addSubscriber(ad1);
-        source.addSubscriber(ad2);
-        source.addSubscriber(ad3);
+        source.addSubscriber(detectorFilter1);
+        source.addSubscriber(detectorFilter2);
+        source.addSubscriber(detectorFilter3);
     
-        ad1.addSubscriber(eval1);
-        ad2.addSubscriber(eval2);
-        ad3.addSubscriber(eval3);
+        detectorFilter1.addSubscriber(eval1);
+        detectorFilter2.addSubscriber(eval2);
+        detectorFilter3.addSubscriber(eval3);
         
-        ad1.addSubscriber(chart1);
-        ad2.addSubscriber(chart2);
-        ad3.addSubscriber(chart3);
+        detectorFilter1.addSubscriber(chart1);
+        detectorFilter2.addSubscriber(chart2);
+        detectorFilter3.addSubscriber(chart3);
         
         eval1.addSubscriber(chart1);
         eval2.addSubscriber(chart2);

--- a/samples/src/main/java/com/expedia/adaptivealerting/samples/Sample001.java
+++ b/samples/src/main/java/com/expedia/adaptivealerting/samples/Sample001.java
@@ -25,9 +25,10 @@ import com.expedia.adaptivealerting.core.anomaly.AnomalyType;
 import com.expedia.adaptivealerting.core.evaluator.RmseEvaluator;
 import com.expedia.adaptivealerting.tools.pipeline.filter.AnomalyDetectorFilter;
 import com.expedia.adaptivealerting.tools.pipeline.filter.EvaluatorFilter;
-import com.expedia.adaptivealerting.tools.pipeline.sink.AnomalyChartSink;
-import com.expedia.adaptivealerting.tools.pipeline.source.MetricFrameMetricSource;
 import com.expedia.adaptivealerting.tools.pipeline.util.PipelineFactory;
+import lombok.val;
+
+import java.util.UUID;
 
 import static com.expedia.adaptivealerting.samples.MetricGenerationHelper.buildMetricFrameMetricSource;
 import static com.expedia.adaptivealerting.tools.visualization.ChartUtil.createChartFrame;
@@ -36,37 +37,40 @@ import static com.expedia.adaptivealerting.tools.visualization.ChartUtil.showCha
 public final class Sample001 {
 
     public static void main(String[] args) throws Exception {
-        MetricFrameMetricSource source = buildMetricFrameMetricSource("samples/sample001.csv", 200L);
+        val source = buildMetricFrameMetricSource("samples/sample001.csv", 200L);
 
-        final EwmaParams ewmaParams = new EwmaParams()
+        val ewmaParams = new EwmaParams()
                 .setAlpha(0.20)
                 .setWeakSigmas(4.5)
                 .setStrongSigmas(5.5);
-        final EwmaAnomalyDetector ewmaAD = new EwmaAnomalyDetector(ewmaParams);
-        final AnomalyDetectorFilter ewmaADF = new AnomalyDetectorFilter(ewmaAD);
+        val ewmaAD = new EwmaAnomalyDetector();
+        ewmaAD.init(UUID.randomUUID(), ewmaParams);
+        val ewmaADF = new AnomalyDetectorFilter(ewmaAD);
 
-        final PewmaParams pewmaParams = new PewmaParams()
+        val pewmaParams = new PewmaParams()
                 .setAlpha(0.20)
                 .setWeakSigmas(5.0)
                 .setStrongSigmas(6.0);
-        final PewmaAnomalyDetector pewmaAD = new PewmaAnomalyDetector(pewmaParams);
-        final AnomalyDetectorFilter pewmaADF = new AnomalyDetectorFilter(pewmaAD);
+        val pewmaAD = new PewmaAnomalyDetector();
+        pewmaAD.init(UUID.randomUUID(), pewmaParams);
+        val pewmaADF = new AnomalyDetectorFilter(pewmaAD);
 
-        final CusumParams cusumParams = new CusumParams()
+        val cusumParams = new CusumParams()
                 .setType(AnomalyType.RIGHT_TAILED)
                 .setTargetValue(20_000_000)
                 .setWeakSigmas(3.0)
                 .setStrongSigmas(4.0)
                 .setInitMeanEstimate(13_000_000);
-        final CusumAnomalyDetector cusumAD = new CusumAnomalyDetector(cusumParams);
-        final AnomalyDetectorFilter cusumADF = new AnomalyDetectorFilter(cusumAD);
+        val cusumAD = new CusumAnomalyDetector();
+        cusumAD.init(UUID.randomUUID(), cusumParams);
+        val cusumADF = new AnomalyDetectorFilter(cusumAD);
 
-        final EvaluatorFilter ewmaEval = new EvaluatorFilter(new RmseEvaluator());
-        final EvaluatorFilter pewmaEval = new EvaluatorFilter(new RmseEvaluator());
+        val ewmaEval = new EvaluatorFilter(new RmseEvaluator());
+        val pewmaEval = new EvaluatorFilter(new RmseEvaluator());
 
-        final AnomalyChartSink ewmaChart = PipelineFactory.createChartSink("EWMA");
-        final AnomalyChartSink pewmaChart = PipelineFactory.createChartSink("PEWMA");
-        final AnomalyChartSink cusumChart = PipelineFactory.createChartSink("CUSUM");
+        val ewmaChart = PipelineFactory.createChartSink("EWMA");
+        val pewmaChart = PipelineFactory.createChartSink("PEWMA");
+        val cusumChart = PipelineFactory.createChartSink("CUSUM");
 
         source.addSubscriber(ewmaADF);
         ewmaADF.addSubscriber(ewmaEval);


### PR DESCRIPTION
The original detector initialization process was somewhat byzantine, with
initialization sometimes happening in constructors and sometimes in the
init() method. This led to a bug with Holt-Winters because we were
initializing with invalid params, and then calling params.validate() and
failing. (This commit fixes that issue.)

The AbstractAnomalyDetector base class is simpler now, and the subclasses
based on that are simpler too. They don't have to implement so many
abstract methods.

Also we were storing weak/strong sigmas in both the detector directly and
in the params object. The detector fields didn't do anything, and this was
leading to confusion about which ones do something and why the values are
different. I removed the detector fields since weak/strong sigmas are in
fact detector params.