### PR TITLE
Replaced Spring HATEOAS with custom code

### DIFF
--- a/anomdetect/pom.xml
+++ b/anomdetect/pom.xml
@@ -65,10 +65,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.hateoas</groupId>
-            <artifactId>spring-hateoas</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSource.java
@@ -62,7 +62,8 @@ public class DefaultDetectorSource implements DetectorSource {
         try {
             return connector
                     .findDetectors(metricDef)
-                    .getContent()
+                    .getEmbedded()
+                    .getDetectors()
                     .stream()
                     .map(resource -> new DetectorMeta(
                             UUID.fromString(resource.getUuid()),

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DetectorResource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DetectorResource.java
@@ -15,10 +15,10 @@
  */
 package com.expedia.adaptivealerting.anomdetect.util;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.hateoas.ResourceSupport;
 
 /**
  * Detector resource.
@@ -26,7 +26,8 @@ import org.springframework.hateoas.ResourceSupport;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class DetectorResource extends ResourceSupport {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetectorResource {
     private String uuid;
     private ModelTypeResource type;
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DetectorResources.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DetectorResources.java
@@ -15,17 +15,31 @@
  */
 package com.expedia.adaptivealerting.anomdetect.util;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.hateoas.Resources;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 /**
  * Detector resources.
  */
-public class DetectorResources extends Resources<DetectorResource> {
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetectorResources {
     
-    @JsonCreator
-    public DetectorResources(@JsonProperty("detectors") Iterable<DetectorResource> resources) {
-        super(resources);
+    @JsonProperty("_embedded")
+    private Embedded embedded = new Embedded();
+    
+    public DetectorResources(List<DetectorResource> list) {
+        embedded.setDetectors(list);
+    }
+    
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Embedded {
+        private List<DetectorResource> detectors;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelResource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelResource.java
@@ -16,17 +16,13 @@
 package com.expedia.adaptivealerting.anomdetect.util;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 import java.util.Map;
 import java.util.UUID;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ModelResource {
     private Long id;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelResources.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelResources.java
@@ -15,17 +15,31 @@
  */
 package com.expedia.adaptivealerting.anomdetect.util;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.hateoas.Resources;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 /**
  * Model resources.
  */
-public class ModelResources extends Resources<ModelResource> {
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ModelResources {
     
-    @JsonCreator
-    public ModelResources(@JsonProperty("models") Iterable<ModelResource> resources) {
-        super(resources);
+    @JsonProperty("_embedded")
+    private Embedded embedded = new Embedded();
+    
+    public ModelResources(List<ModelResource> list) {
+        embedded.setModels(list);
+    }
+    
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Embedded {
+        private List<ModelResource> models;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelTypeResource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/ModelTypeResource.java
@@ -15,10 +15,10 @@
  */
 package com.expedia.adaptivealerting.anomdetect.util;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.hateoas.ResourceSupport;
 
 /**
  * Model type resource.
@@ -28,6 +28,7 @@ import org.springframework.hateoas.ResourceSupport;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ModelTypeResource extends ResourceSupport {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ModelTypeResource {
     private String key;
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSourceTest.java
@@ -19,6 +19,7 @@ import com.expedia.adaptivealerting.anomdetect.AnomalyDetector;
 import com.expedia.adaptivealerting.anomdetect.ewma.EwmaAnomalyDetector;
 import com.expedia.adaptivealerting.anomdetect.util.DetectorMeta;
 import com.expedia.adaptivealerting.anomdetect.util.DetectorResource;
+import com.expedia.adaptivealerting.anomdetect.util.DetectorResources;
 import com.expedia.adaptivealerting.anomdetect.util.ModelResource;
 import com.expedia.adaptivealerting.anomdetect.util.ModelServiceConnector;
 import com.expedia.adaptivealerting.anomdetect.util.ModelTypeResource;
@@ -29,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.hateoas.Resources;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -56,7 +56,7 @@ public final class DefaultDetectorSourceTest {
     private DetectorMeta detectorMeta;
     private DetectorMeta detectorMetaMissingDetector;
     private DetectorMeta detectorMetaException;
-    private Resources<DetectorResource> detectorResources;
+    private DetectorResources detectorResources;
     private ModelResource modelResource;
     private AnomalyDetector detector;
 
@@ -120,7 +120,7 @@ public final class DefaultDetectorSourceTest {
         this.detectorMetaException = new DetectorMeta(DETECTOR_UUID_EXCEPTION, DETECTOR_TYPE);
 
         val detectorResource = new DetectorResource(DETECTOR_UUID.toString(), new ModelTypeResource(DETECTOR_TYPE));
-        this.detectorResources = new Resources<>(Collections.singletonList(detectorResource));
+        this.detectorResources = new DetectorResources(Collections.singletonList(detectorResource));
 
         val params = new HashMap<String, Object>();
         params.put("alpha", 0.2);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/ModelServiceConnectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/ModelServiceConnectorTest.java
@@ -53,14 +53,6 @@ public class ModelServiceConnectorTest {
     
     private ModelServiceConnector connectorUnderTest;
     private MetricTankIdFactory metricTankIdFactory = new MetricTankIdFactory();
-    
-    // This is just a basic ObjectMapper rather than a Jackson2ObjectMapper, since we are
-    // just writing JSON here. (If we try to use the Jackson2ObjectMapper that we use in the
-    // ModelServiceConnector we get an error:
-    //
-    // com.fasterxml.jackson.databind.JsonMappingException:
-    //     Class org.springframework.hateoas.hal.Jackson2HalModule$HalResourcesSerializer
-    //     has no default (no arg) constructor
     private ObjectMapper objectMapper = new ObjectMapper();
     
     @Mock
@@ -72,7 +64,7 @@ public class ModelServiceConnectorTest {
     private MetricDefinition metricDefinition;
     private Content detectorResourcesContent;
     private Content modelResourcesContent;
-    private Content modelResourcesContent_empty;
+    private Content emptyModelResourcesContent;
     
     @Before
     public void setUp() throws Exception {
@@ -101,7 +93,7 @@ public class ModelServiceConnectorTest {
     @Test
     public void testFindDetectors() throws Exception {
         val result = connectorUnderTest.findDetectors(metricDefinition);
-        assertEquals(detectorResourceList.size(), result.getContent().size());
+        assertEquals(detectorResourceList.size(), result.getEmbedded().getDetectors().size());
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -139,31 +131,24 @@ public class ModelServiceConnectorTest {
         detectorResourceList.add(new DetectorResource(
                 "90c37a3c-f6bb-4c00-b41b-191909cccfb7",
                 new ModelTypeResource(EWMA_DETECTOR)));
-        val detectorResourcesBytes = writeValueAsBytesHack("detectors", detectorResourceList);
+        val detectorResources = new DetectorResources(detectorResourceList);
+        val detectorResourcesBytes = objectMapper.writeValueAsBytes(detectorResources);
         this.detectorResourcesContent = new Content(detectorResourcesBytes, ContentType.APPLICATION_JSON);
-        log.info("detectorResourcesContent={}", detectorResourcesContent);
         
         // Find models
         this.modelResourceList = new ArrayList<>();
         modelResourceList.add(new ModelResource());
-        val modelResourcesBytes = writeValueAsBytesHack("models", modelResourceList);
+        val modelResources = new ModelResources(modelResourceList);
+        val modelResourcesBytes = objectMapper.writeValueAsBytes(modelResources);
         this.modelResourcesContent = new Content(modelResourcesBytes, ContentType.APPLICATION_JSON);
-        log.info("modelResourcesContent={}", modelResourcesContent);
         
         // Find models - empty list
-        val modelResources_empty = new ModelResources(Collections.EMPTY_LIST);
-        val modelResourcesBytes_empty = writeValueAsBytesHack("models", Collections.EMPTY_LIST);
-        this.modelResourcesContent_empty = new Content(modelResourcesBytes_empty, ContentType.APPLICATION_JSON);
-    }
-    
-    // This is a hack to deal with the fact I can't build an ObjectMapper with the required serializer here. (I want to
-    // use Jackson2HalModule, and I can do that, but then we get an error during serializer initialization since the
-    // module's serializer doesn't have a default constructor.) So I am just putting the list key at the top-level here
-    // instead of using _embedded.<list_key>, which is what the Model Service actually generates. [WLW]
-    private byte[] writeValueAsBytesHack(String key, List<?> resourceList) throws IOException {
-        val detectorResourceMap = new HashMap<String, Object>();
-        detectorResourceMap.put(key, resourceList);
-        return objectMapper.writeValueAsBytes(detectorResourceMap);
+        val emptyModelResourcesEmbedded = new ModelResources.Embedded();
+        emptyModelResourcesEmbedded.setModels(Collections.EMPTY_LIST);
+        val emptyModelResources = new ModelResources();
+        emptyModelResources.setEmbedded(emptyModelResourcesEmbedded);
+        val emptyModelResourcesBytes = objectMapper.writeValueAsBytes(emptyModelResources);
+        this.emptyModelResourcesContent = new Content(emptyModelResourcesBytes, ContentType.APPLICATION_JSON);
     }
     
     private void initDependencies() throws IOException {
@@ -174,6 +159,6 @@ public class ModelServiceConnectorTest {
         
         when(httpClient.get(findDetectorsUri)).thenReturn(detectorResourcesContent);
         when(httpClient.get(findModelsUri)).thenReturn(modelResourcesContent);
-        when(httpClient.get(findModelsUri_empty)).thenReturn(modelResourcesContent_empty);
+        when(httpClient.get(findModelsUri_empty)).thenReturn(emptyModelResourcesContent);
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/ModelServiceConnectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/ModelServiceConnectorTest.java
@@ -143,10 +143,7 @@ public class ModelServiceConnectorTest {
         this.modelResourcesContent = new Content(modelResourcesBytes, ContentType.APPLICATION_JSON);
         
         // Find models - empty list
-        val emptyModelResourcesEmbedded = new ModelResources.Embedded();
-        emptyModelResourcesEmbedded.setModels(Collections.EMPTY_LIST);
-        val emptyModelResources = new ModelResources();
-        emptyModelResources.setEmbedded(emptyModelResourcesEmbedded);
+        val emptyModelResources = new ModelResources(Collections.EMPTY_LIST);
         val emptyModelResourcesBytes = objectMapper.writeValueAsBytes(emptyModelResources);
         this.emptyModelResourcesContent = new Content(emptyModelResourcesBytes, ContentType.APPLICATION_JSON);
     }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/MetricRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/MetricRepository.java
@@ -59,6 +59,7 @@ public interface MetricRepository extends PagingAndSortingRepository<Metric, Lon
      * Finds a list of metrics by its matching key.
      *
      * @param key Matching key.
+     * @param pageable paging params
      * @return List of metrics by its matching key
      */
     @Query(nativeQuery = true, value = "SELECT * FROM metric m WHERE m.ukey LIKE :key order by m.ukey", countQuery = "SELECT count(*) FROM metric m WHERE m.ukey LIKE :key")
@@ -81,6 +82,4 @@ public interface MetricRepository extends PagingAndSortingRepository<Metric, Lon
      */
     @Query("select mmm.metric from MetricDetectorMapping mmm where mmm.detector.uuid = :uuid")
     List<Metric> findByDetectorUuid(@Param("uuid") String uuid);
-
-
 }


### PR DESCRIPTION
We were having some trouble with the Spring HATEOAS-based Jackson module,
as the serializer doesn't have a noarg constructor, and the unit tests
were failing when trying to create a serializer. So this commit replaces
that with custom resource objects, which is nice anyway because it allows
us to avoid pulling in a bunch of Spring dependencies just for a few
resources.