### PR TITLE
Pre-create index mapping for detector index

### DIFF
--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -115,6 +115,8 @@ module "modelservice" {
   detector_mapper_es_urls = "${var.modelservice["detector_mapper_es_urls"]}"
   detector_mapper_index_name = "${var.modelservice["detector_mapper_index_name"]}"
   detector_mapper_doctype = "${var.modelservice["detector_mapper_doctype"]}"
+  detector_index_name = "${var.modelservice["detector_index_name"]}"
+  detector_doctype = "${var.modelservice["detector_doctype"]}"
   detector_mapper_es_config_connection_timeout = "${var.modelservice["detector_mapper_es_config_connection_timeout"]}"
   detector_mapper_es_config_connection_retry_timeout = "${var.modelservice["detector_mapper_es_config_connection_retry_timeout"]}"
   detector_mapper_es_config_max_total_connection = "${var.modelservice["detector_mapper_es_config_max_total_connection"]}"

--- a/deployment/terraform/modelservice/main.tf
+++ b/deployment/terraform/modelservice/main.tf
@@ -15,6 +15,8 @@ data "template_file" "config_data" {
     detector_mapper_es_urls = "${var.detector_mapper_es_urls}"
     detector_mapper_index_name = "${var.detector_mapper_index_name}"
     detector_mapper_doctype = "${var.detector_mapper_doctype}"
+    detector_index_name = "${var.detector_index_name}"
+    detector_doctype = "${var.detector_doctype}"
     detector_mapper_es_config_connection_timeout = "${var.detector_mapper_es_config_connection_timeout}"
     detector_mapper_es_config_connection_retry_timeout = "${var.detector_mapper_es_config_connection_retry_timeout}"
     detector_mapper_es_config_max_total_connection = "${var.detector_mapper_es_config_max_total_connection}"

--- a/deployment/terraform/modelservice/templates/application_yaml.tpl
+++ b/deployment/terraform/modelservice/templates/application_yaml.tpl
@@ -22,6 +22,8 @@ datasource-es:
   createIndexIfNotFound: true
   indexName: ${detector_mapper_index_name}
   doctype: ${detector_mapper_doctype}
+  detectorIndexName: ${detector_index_name}
+  detectorDocType: ${detector_doctype}
   urls: ${detector_mapper_es_urls}
   config: 
     connectionTimeout: ${detector_mapper_es_config_connection_timeout}

--- a/deployment/terraform/modelservice/variables.tf
+++ b/deployment/terraform/modelservice/variables.tf
@@ -36,6 +36,8 @@ variable "graphite_url" {}
 variable "detector_mapper_es_urls" {}
 variable "detector_mapper_index_name" {}
 variable "detector_mapper_doctype" {}
+variable "detector_index_name" {}
+variable "detector_doctype" {}
 variable "detector_mapper_es_config_connection_timeout" {}
 variable "detector_mapper_es_config_connection_retry_timeout" {}
 variable "detector_mapper_es_config_max_total_connection" {}

--- a/modelservice/application.yml.sample
+++ b/modelservice/application.yml.sample
@@ -39,8 +39,10 @@ server:
 # Elasticsearch
 datasource-es:
   createIndexIfNotFound: true
-  indexName: ${ES_INDEX_NAME}
-  doctype: ${ES_DOCTYPE}
+  indexName: ${ES_MAPPING_INDEX_NAME}
+  doctype: ${ES_MAPPING_DOCTYPE}
+  detectorIndexName: ${ES_DETECTOR_INDEX_NAME}
+  detectorDoctype: ${ES_DETECTOR_DOCTYPE}
   urls: ${ES_URL}
   config:
     connectionTimeout: 40000

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/percolator/PercolatorDetectorMapping.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/percolator/PercolatorDetectorMapping.java
@@ -37,6 +37,12 @@ public class PercolatorDetectorMapping {
     public static final String LAST_MOD_TIME_KEYWORD = AA_PREFIX + "lastModifiedTime";
     public static final String CREATE_TIME_KEYWORD = AA_PREFIX + "createdTime";
 
+    public static final String DETECTOR_MOD_TIME = "lastUpdateTimestamp";
+    public static final String DETECTOR_CREATED_TIME = "dateCreated";
+    public static final String DETECTOR_TYPE = "type";
+    public static final String DETECTOR_CREATED_BY = "createdBy";
+    public static final String DETECTOR_CONFIG = "detectorConfig";
+
     @JsonProperty(USER_KEYWORD)
     private User user;
     @JsonProperty(DETECTOR_KEYWORD)

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
@@ -39,6 +39,8 @@ public class ElasticSearchProperties {
     private boolean createIndexIfNotFound;
     private String docType;
     private String urls;
+    private String detectorIndexName;
+    private String detectorDocType;
 
     @Data
     @Accessors(chain = true)

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorIndexCreatorIfNotPresent.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorIndexCreatorIfNotPresent.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.util;
+
+import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchClient;
+import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchProperties;
+import com.google.gson.JsonObject;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_TYPE;
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_ID_KEYWORD;
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_MOD_TIME;
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_CREATED_TIME;
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_CREATED_BY;
+import static com.expedia.adaptivealerting.modelservice.dto.percolator.PercolatorDetectorMapping.DETECTOR_CONFIG;
+
+/**
+ * Util class to create index with mappings if not found.
+ */
+@Component
+@Slf4j
+public class DetectorIndexCreatorIfNotPresent implements ApplicationListener<ApplicationReadyEvent> {
+
+    @Autowired
+    private ElasticSearchProperties properties;
+
+    @Autowired
+    private ElasticSearchClient client;
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent applicationReadyEvent) {
+        if (properties.isCreateIndexIfNotFound() && properties.getDetectorIndexName() != null && properties.getDetectorDocType() != null) {
+            try {
+                boolean isPresent = client.indices().exists(getIndexRequest(), RequestOptions.DEFAULT);
+                if (!isPresent) {
+                    val response = client.indices().create(createIndexRequest(), RequestOptions.DEFAULT);
+                    if (!response.isAcknowledged()) {
+                        throw new RuntimeException("Index creation failed");
+                    }
+                    log.info("Successfully created index: {}", properties.getDetectorIndexName());
+                }
+            } catch (IOException e) {
+                log.error("Index creation failed", e);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private GetIndexRequest getIndexRequest() {
+        val request = new GetIndexRequest();
+        request.indices(properties.getDetectorIndexName());
+        return request;
+    }
+
+    private CreateIndexRequest createIndexRequest() {
+        val docObject = new JsonObject();
+        docObject.addProperty("dynamic", "false");
+        docObject.add("properties", buildMappingsJson());
+
+        val mapObject = new JsonObject();
+        mapObject.add(properties.getDetectorDocType(), docObject);
+
+        val request = new CreateIndexRequest(properties.getDetectorIndexName());
+        request.settings(Settings.builder()
+                .put("index.number_of_shards", 5)
+                .put("index.number_of_replicas", 3)
+        );
+        request.mapping(properties.getDetectorDocType(), mapObject.toString(), XContentType.JSON);
+        return request;
+    }
+
+    private JsonObject buildMappingsJson() {
+        val dynamicType = new JsonObject();
+        dynamicType.addProperty("type", "nested");
+        dynamicType.addProperty("dynamic", "true");
+
+        val keywordType = new JsonObject();
+        keywordType.addProperty("type", "keyword");
+
+        val textType = new JsonObject();
+        textType.addProperty("type", "text");
+
+        val dateType = new JsonObject();
+        dateType.addProperty("type", "date");
+
+        val formattedDateType = new JsonObject();
+        formattedDateType.addProperty("type", "date");
+        formattedDateType.addProperty("format", "yyyy-MM-dd HH:mm:ss");
+
+        val propObject = new JsonObject();
+        propObject.add(DETECTOR_CONFIG, dynamicType);
+        propObject.add(DETECTOR_TYPE, textType);
+        propObject.add(DETECTOR_ID_KEYWORD, keywordType);
+        propObject.add(DETECTOR_MOD_TIME, formattedDateType);
+        propObject.add(DETECTOR_CREATED_TIME, dateType);
+        propObject.add(DETECTOR_CREATED_BY, keywordType);
+        return propObject;
+    }
+}

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/util/DetectorIndexCreatorIfNotPresentTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/util/DetectorIndexCreatorIfNotPresentTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.util;
+
+import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchClient;
+import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+import static org.mockito.Mockito.when;
+
+public class DetectorIndexCreatorIfNotPresentTest {
+
+    @InjectMocks
+    private DetectorIndexCreatorIfNotPresent creatorUnderTest;
+
+    @Mock
+    private ElasticSearchProperties esProperties;
+
+    @Mock
+    private ElasticSearchClient esClient;
+
+    // TODO Can't mock this because it's final.
+    //  Might want to make some kind of a DAO wrapper around the Elasticsearch client,
+    //  including the IndicesClient. [WLW]
+//    @Mock
+//    private IndicesClient indicesClient;
+
+    @Mock
+    private ApplicationReadyEvent appReadyEvent;
+
+    @Before
+    public void setUp() {
+        this.creatorUnderTest = new DetectorIndexCreatorIfNotPresent();
+        MockitoAnnotations.initMocks(this);
+        initDependencies();
+    }
+
+    @Test
+    public void testOnApplicationEvent() {
+//        creatorUnderTest.onApplicationEvent(appReadyEvent);
+        // TODO
+    }
+
+    private void initDependencies() {
+        when(esProperties.isCreateIndexIfNotFound()).thenReturn(true);
+        when(esProperties.getIndexName()).thenReturn("my-index");
+
+//        when(esClient.indices()).thenReturn(indicesClient);
+    }
+}


### PR DESCRIPTION
Adds new class to pre-create index mappings for detectors elasticsearch index if it does not exist.
This is required to spin up a working docker-compose instance of this project from scratch.

This adds additional index name and doctype parameters to the application.yml for the modelservice. If the new parameters are not present the index creation process is not started to remain compatible with existing configs.