### PR TITLE
Ignore box key from tags

### DIFF
--- a/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSource.java
+++ b/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSource.java
@@ -46,6 +46,7 @@ public class DefaultProfileSource implements ProfileSource {
     public Boolean profileExists(MetricDefinition metricDefinition) {
         AssertUtil.notNull(metricDefinition, "metricDefinition can't be null");
         val tags = metricDefinition.getTags().getKv();
+        tags.remove("box");
 
         isTrue(tags.size() > 0, "tags must not be empty");
 


### PR DESCRIPTION
Ignore box (IP) key from tags as profiling will remain the same for a given set of metrics.