### PR TITLE
Enhacement/metric profiler batch calls

### DIFF
--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMetricProfiler.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMetricProfiler.java
@@ -15,17 +15,12 @@
  */
 package com.expedia.adaptivealerting.kafka;
 
-import com.expedia.adaptivealerting.anomdetect.detect.MappedMetricData;
-import com.expedia.adaptivealerting.anomdetect.mapper.MapperResult;
-import com.expedia.adaptivealerting.anomdetect.util.AssertUtil;
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
-import com.expedia.adaptivealerting.kafka.processor.MetricDataTransformerSupplier;
 import com.expedia.adaptivealerting.kafka.processor.MetricProfilerTransformerSupplier;
 import com.expedia.adaptivealerting.kafka.serde.MetricDataJsonSerde;
 import com.expedia.adaptivealerting.metricprofiler.MetricProfiler;
 import com.expedia.adaptivealerting.metricprofiler.source.DefaultProfileSource;
 import com.expedia.metrics.MetricData;
-import com.expedia.metrics.metrictank.MetricTankIdFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.Config;
 import lombok.Getter;
@@ -33,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
@@ -41,8 +35,6 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-
-import java.util.stream.Collectors;
 
 import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMetricProfiler.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/KafkaMetricProfiler.java
@@ -15,6 +15,9 @@
  */
 package com.expedia.adaptivealerting.kafka;
 
+import com.expedia.adaptivealerting.anomdetect.detect.MappedMetricData;
+import com.expedia.adaptivealerting.anomdetect.mapper.MapperResult;
+import com.expedia.adaptivealerting.anomdetect.util.AssertUtil;
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
 import com.expedia.adaptivealerting.kafka.processor.MetricDataTransformerSupplier;
 import com.expedia.adaptivealerting.kafka.processor.MetricProfilerTransformerSupplier;
@@ -39,17 +42,18 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 
+import java.util.stream.Collectors;
+
 import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 
 @Slf4j
 public final class KafkaMetricProfiler extends AbstractStreamsApp {
     private static final String CK_METRIC_PROFILER = "metric-profiler";
-    private static final String stateStoreName = "ms-request-buffer";
+    private static final String stateStoreName = "profiler-request-buffer";
     private static final String CK_MODEL_SERVICE_URI_TEMPLATE = "model-service-base-uri";
 
     private Serde<String> outputKeySerde = new Serdes.StringSerde();
     private Serde<MetricData> outputValueSerde = new MetricDataJsonSerde();
-    private final MetricTankIdFactory idFactory = new MetricTankIdFactory();
 
     @Getter
     private final MetricProfiler metricProfiler;

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expedia.adaptivealerting.kafka.processor;
 
 import com.expedia.adaptivealerting.metricprofiler.MetricProfiler;

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
@@ -59,7 +59,7 @@ public class MetricProfilerTransformer implements Transformer<String, MetricData
                 Map<String, MetricData> metricsToBeProfiled = getMapAndFlushStore();
                 metricsToBeProfiled.forEach((originalKey, metricData) -> {
                     Boolean profilingInfo = metricProfiler.hasProfilingInfo(metricData.getMetricDefinition());
-                    if (profilingInfo == null) {
+                    if (!profilingInfo) {
                         context.forward(originalKey, metricData);
                     }
                 });
@@ -73,8 +73,10 @@ public class MetricProfilerTransformer implements Transformer<String, MetricData
 
     @Override
     public KeyValue<String, MetricData> transform(String key, MetricData metricData) {
-        Boolean profilingInfo = metricProfiler.hasProfilingInfo(metricData.getMetricDefinition());
+        Boolean profilingInfo = metricProfiler.getProfilingInfoFromCache(metricData.getMetricDefinition());
         if (profilingInfo == null) {
+            this.metricDataKeyValueStore.put(key, metricData);
+        } else if (!profilingInfo) {
             return new KeyValue<>(key, metricData);
         }
         return null;

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformer.java
@@ -1,0 +1,91 @@
+package com.expedia.adaptivealerting.kafka.processor;
+
+import com.expedia.adaptivealerting.metricprofiler.MetricProfiler;
+import com.expedia.metrics.MetricData;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Slf4j
+public class MetricProfilerTransformer implements Transformer<String, MetricData, KeyValue<String, MetricData>> {
+
+    private ProcessorContext context;
+    private KeyValueStore<String, MetricData> metricDataKeyValueStore;
+
+    @NonNull
+    private MetricProfiler metricProfiler;
+
+    @NonNull
+    private final String stateStoreName;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void init(ProcessorContext context) {
+        this.context = context;
+        this.metricDataKeyValueStore = (KeyValueStore<String, MetricData>) context.getStateStore(stateStoreName);
+
+        /*
+         *  Requests to model-service to fetch profiling info for metrics are throttled
+         *  This is done by buffering them in kafka KV store and periodically clearing that buffer
+         *
+         */
+        this.context.schedule(200, PunctuationType.WALL_CLOCK_TIME, (timestamp) -> {
+            if (metricDataKeyValueStore.approximateNumEntries() >= metricProfiler.optimalBatchSize()) {
+                Map<String, MetricData> metricsToBeProfiled = getMapAndFlushStore();
+                metricsToBeProfiled.forEach((originalKey, metricData) -> {
+                    Boolean profilingInfo = metricProfiler.hasProfilingInfo(metricData.getMetricDefinition());
+                    if (profilingInfo == null) {
+                        context.forward(originalKey, metricData);
+                    }
+                });
+            } else {
+                log.trace("ES lookup skipped, as batch size is not optimum");
+            }
+            context.commit();
+        });
+
+    }
+
+    @Override
+    public KeyValue<String, MetricData> transform(String key, MetricData metricData) {
+        Boolean profilingInfo = metricProfiler.hasProfilingInfo(metricData.getMetricDefinition());
+        if (profilingInfo == null) {
+            return new KeyValue<>(key, metricData);
+        }
+        return null;
+    }
+
+    @Override
+    public KeyValue<String, MetricData> punctuate(long timestamp) {
+        return null;
+    }
+
+
+    @Override
+    public void close() {
+    }
+
+    private Map<String, MetricData> getMapAndFlushStore() {
+        KeyValueIterator<String, MetricData> iter = this.metricDataKeyValueStore.all();
+        Map<String, MetricData> metricsToBeProfiled = new HashMap<>();
+
+        while (iter.hasNext()) {
+            KeyValue<String, MetricData> entry = iter.next();
+            metricsToBeProfiled.put(entry.key, entry.value);
+            metricDataKeyValueStore.delete(entry.key);
+        }
+        iter.close();
+        return metricsToBeProfiled;
+    }
+}
+

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformerSupplier.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformerSupplier.java
@@ -1,0 +1,28 @@
+package com.expedia.adaptivealerting.kafka.processor;
+
+import com.expedia.adaptivealerting.anomdetect.mapper.DetectorMapper;
+import com.expedia.adaptivealerting.anomdetect.mapper.MapperResult;
+import com.expedia.adaptivealerting.metricprofiler.MetricProfiler;
+import com.expedia.metrics.MetricData;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+
+@RequiredArgsConstructor
+@Data
+public class MetricProfilerTransformerSupplier implements TransformerSupplier<String, MetricData, KeyValue<String, MetricData>> {
+
+    @NonNull
+    private MetricProfiler metricProfiler;
+
+    @NonNull
+    private final String stateStoreName;
+
+    @Override
+    public Transformer<String, MetricData, KeyValue<String, MetricData>> get() {
+        return new MetricProfilerTransformer(metricProfiler, stateStoreName);
+    }
+}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformerSupplier.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/kafka/processor/MetricProfilerTransformerSupplier.java
@@ -1,7 +1,20 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expedia.adaptivealerting.kafka.processor;
 
-import com.expedia.adaptivealerting.anomdetect.mapper.DetectorMapper;
-import com.expedia.adaptivealerting.anomdetect.mapper.MapperResult;
 import com.expedia.adaptivealerting.metricprofiler.MetricProfiler;
 import com.expedia.metrics.MetricData;
 import lombok.Data;

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
@@ -86,17 +86,15 @@ public class KafkaMetricProfilerTest {
     public void tearDown() {
         logAndFailDriver.close();
     }
-/*
+
     @Test
     public void testTransform() {
         logAndFailDriver.pipeInput(metricDataFactory.create(INPUT_TOPIC, KAFKA_KEY, metricData));
         val outputRecord = logAndFailDriver.readOutput(OUTPUT_TOPIC, stringDeserializer, metricDataDeserializer);
         log.trace("outputRecord={}", outputRecord);
-        val expectedKey = idFactory.getId((metricData.getMetricDefinition()));
-        log.info("expectedKey:{}", outputRecord);
-        OutputVerifier.compareKeyValue(outputRecord, expectedKey, metricData);
+        OutputVerifier.compareKeyValue(outputRecord, "some-kafka-key", metricData);
     }
-*/
+
     @Test
     public void testBuildMetricProfiler() {
         val config = ConfigFactory.load("metric-profiler.conf");

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
@@ -37,9 +37,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import sun.jvm.hotspot.runtime.ObjectMonitor;
-
-import java.time.Instant;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -108,7 +105,7 @@ public class KafkaMetricProfilerTest {
         log.trace("outputRecord={}", outputRecord);
         OutputVerifier.compareKeyValue(outputRecord, "some-kafka-key", notProfileMetricData);
     }
-    
+
     @Test
     public void testBuildMetricProfiler() {
         val config = ConfigFactory.load("metric-profiler.conf");

--- a/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
+++ b/kafka/src/test/java/com.expedia.adaptivealerting.kafka/KafkaMetricProfilerTest.java
@@ -86,16 +86,17 @@ public class KafkaMetricProfilerTest {
     public void tearDown() {
         logAndFailDriver.close();
     }
-
+/*
     @Test
     public void testTransform() {
         logAndFailDriver.pipeInput(metricDataFactory.create(INPUT_TOPIC, KAFKA_KEY, metricData));
         val outputRecord = logAndFailDriver.readOutput(OUTPUT_TOPIC, stringDeserializer, metricDataDeserializer);
         log.trace("outputRecord={}", outputRecord);
         val expectedKey = idFactory.getId((metricData.getMetricDefinition()));
+        log.info("expectedKey:{}", outputRecord);
         OutputVerifier.compareKeyValue(outputRecord, expectedKey, metricData);
     }
-
+*/
     @Test
     public void testBuildMetricProfiler() {
         val config = ConfigFactory.load("metric-profiler.conf");

--- a/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MatchedMetricResponse.java
+++ b/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MatchedMetricResponse.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.metricprofiler.source;
+package com.expedia.adaptivealerting.metricprofiler;
 
-import com.expedia.adaptivealerting.metricprofiler.MatchedMetricResponse;
-import com.expedia.metrics.MetricDefinition;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-import java.util.Map;
 
-public interface ProfileSource {
-    MatchedMetricResponse profileExists(MetricDefinition metricDefinition);
+@Data
+@AllArgsConstructor
+public class MatchedMetricResponse {
+    private String id;
+    private long lookupTimeInMillis;
 }

--- a/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MetricProfiler.java
+++ b/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MetricProfiler.java
@@ -89,11 +89,20 @@ public class MetricProfiler {
         return profileExists;
     }
 
+    public Boolean getProfilingInfoFromCache(MetricDefinition metricDefinition){
+        return cachedMetrics.get(idFactory.getId(metricDefinition));
+    }
+
+    /**
+     * Finds the optimal batch size by looking at the elastic search latency
+     *
+     * @return Optimal batch size
+     */
     public int optimalBatchSize() {
         if (lastElasticLookUpLatency.longValue() == -1L || lastElasticLookUpLatency.longValue() > 100L) {
             return 80;
         }
-        return 0;
+        return 100;
     }
 
 }

--- a/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MetricProfiler.java
+++ b/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/MetricProfiler.java
@@ -102,7 +102,7 @@ public class MetricProfiler {
         if (lastElasticLookUpLatency.longValue() == -1L || lastElasticLookUpLatency.longValue() > 100L) {
             return 80;
         }
-        return 100;
+        return 0;
     }
 
 }

--- a/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSource.java
+++ b/metricprofiler/src/main/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSource.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.metricprofiler.source;
 
 import com.expedia.adaptivealerting.anomdetect.util.AssertUtil;
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
+import com.expedia.adaptivealerting.metricprofiler.MatchedMetricResponse;
 import com.expedia.metrics.MetricDefinition;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
@@ -45,7 +46,7 @@ public class DefaultProfileSource implements ProfileSource {
     public static final String FIND_DOCUMENT_PATH = "/api/metricProfiling/search/findByTags";
 
     @Override
-    public Boolean profileExists(MetricDefinition metricDefinition) {
+    public MatchedMetricResponse profileExists(MetricDefinition metricDefinition) {
         AssertUtil.notNull(metricDefinition, "metricDefinition can't be null");
         val tags = metricDefinition.getTags().getKv();
         val mutableTags = getMutableTagsMap(tags);
@@ -64,8 +65,7 @@ public class DefaultProfileSource implements ProfileSource {
             throw new RuntimeException(message, e);
         }
         try {
-            objectMapper.readValue(content.asBytes(), Boolean.class);
-            return true;
+            return objectMapper.readValue(content.asBytes(), MatchedMetricResponse.class);
         } catch (IOException e) {
             val message = "IOException while finding finding matching profile: tags=" + mutableTags;
             throw new RuntimeException(message, e);

--- a/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/MetricProfilerTest.java
+++ b/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/MetricProfilerTest.java
@@ -10,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -45,6 +44,13 @@ public class MetricProfilerTest {
         val result = metricProfiler.hasProfilingInfo(goodDefinition);
         assertNotNull(result);
         assertEquals(true, result);
+    }
+
+    @Test
+    public void testOptimalBatchSize() {
+        val result = metricProfiler.optimalBatchSize();
+        assertNotNull(result);
+        assertEquals(80, result);
     }
 
     private void initTestObjects() {

--- a/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/MetricProfilerTest.java
+++ b/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/MetricProfilerTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -29,6 +30,8 @@ public class MetricProfilerTest {
 
     private MetricDefinition goodDefinition;
 
+    private MatchedMetricResponse metricResponse;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -46,9 +49,10 @@ public class MetricProfilerTest {
 
     private void initTestObjects() {
         this.goodDefinition = new MetricDefinition("good-definition");
+        this.metricResponse = new MatchedMetricResponse("1", 100L);
     }
 
     private void initDependencies() {
-        when(source.profileExists(Mockito.any(MetricDefinition.class))).thenReturn(true);
+        when(source.profileExists(Mockito.any(MetricDefinition.class))).thenReturn(metricResponse);
     }
 }

--- a/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSourceTest.java
+++ b/metricprofiler/src/test/java/com/expedia/adaptivealerting/metricprofiler/source/DefaultProfileSourceTest.java
@@ -1,6 +1,7 @@
 package com.expedia.adaptivealerting.metricprofiler.source;
 
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
+import com.expedia.adaptivealerting.metricprofiler.MatchedMetricResponse;
 import com.expedia.metrics.MetricDefinition;
 import com.expedia.metrics.TagCollection;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +41,7 @@ public class DefaultProfileSourceTest {
     private Map<String, String> metricTags_cantRead;
     private Map<String, String> metricTags_invalidContent;
 
+    private MatchedMetricResponse metricResponse;
 
     @Mock
     private Content docContent;
@@ -73,7 +75,7 @@ public class DefaultProfileSourceTest {
 
         goodDefinition = new MetricDefinition("good-definition", tags, meta);
         val result = classUnderTest.profileExists(goodDefinition);
-        assertEquals(true, result);
+        assertEquals("1", result.getId());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -98,6 +100,7 @@ public class DefaultProfileSourceTest {
         this.metricTags = new HashMap<>();
         this.metricTags_cantRead = new HashMap<>();
         this.metricTags_invalidContent = new HashMap<>();
+        this.metricResponse = new MatchedMetricResponse("1", 1000L);
     }
 
     @SneakyThrows
@@ -105,7 +108,7 @@ public class DefaultProfileSourceTest {
         when(objectMapper.writeValueAsString(metricTags)).thenReturn(tagsBody);
         when(httpClient.post(FIND_DOC_URI, tagsBody)).thenReturn(docContent);
         when(docContent.asBytes()).thenReturn(docBytes);
-        when(objectMapper.readValue(docBytes, Boolean.class)).thenReturn(true);
+        when(objectMapper.readValue(docBytes, MatchedMetricResponse.class)).thenReturn(metricResponse);
 
         when(objectMapper.writeValueAsString(metricTags_cantRead)).thenReturn(tagsBody_cantRead);
         when(httpClient.post(FIND_DOC_URI, tagsBody_cantRead)).thenThrow(new IOException());
@@ -113,7 +116,7 @@ public class DefaultProfileSourceTest {
         when(objectMapper.writeValueAsString(metricTags_invalidContent)).thenReturn(tagsBody_invalidContent);
         when(httpClient.post(FIND_DOC_URI, tagsBody_invalidContent)).thenReturn(invalidDocContent);
         when(invalidDocContent.asBytes()).thenReturn(invalidDocBytes);
-        when(objectMapper.readValue(invalidDocBytes, Boolean.class)).thenThrow(new IOException());
+        when(objectMapper.readValue(invalidDocBytes, MatchedMetricResponse.class)).thenThrow(new IOException());
     }
 
     private static String uri(String path) {

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/metricprofiling/MatchedMetricResponse.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/metricprofiling/MatchedMetricResponse.java
@@ -15,10 +15,14 @@
  */
 package com.expedia.adaptivealerting.modelservice.dto.metricprofiling;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MatchedMetricResponse {
     private String id;
     private long lookupTimeInMillis;

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/metricprofiling/MatchedMetricResponse.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/dto/metricprofiling/MatchedMetricResponse.java
@@ -15,14 +15,11 @@
  */
 package com.expedia.adaptivealerting.modelservice.dto.metricprofiling;
 
-import com.expedia.adaptivealerting.modelservice.dto.detectormapping.Detector;
 import lombok.Data;
 
-import java.util.List;
-import java.util.Map;
 
 @Data
 public class MatchedMetricResponse {
-    private Map<Integer, List<Detector>> groupedDetectorsBySearchIndex;
+    private String id;
     private long lookupTimeInMillis;
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepository.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.modelservice.repo;
 
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -26,5 +27,5 @@ public interface MetricProfilingRepository {
 
     void updateMetricProfile(String id, Boolean isStationary);
 
-    Boolean profilingExists(Map<String, String> tags);
+    MatchedMetricResponse profilingExists(Map<String, String> tags);
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/MetricProfilingRepositoryImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/MetricProfilingRepositoryImpl.java
@@ -119,7 +119,6 @@ public class MetricProfilingRepositoryImpl implements MetricProfilingRepository 
             val hits = searchResponse.getHits().getHits();
 
             MatchedMetricResponse response = new MatchedMetricResponse();
-
             for (val hit : hits) {
                 response.setId(hit.getId());
             }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingService.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.modelservice.service;
 
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,6 @@ public interface MetricProfilingService {
 
     void updateMetricProfile(String id, Boolean isStationary);
 
-    Boolean profilingExists(Map<String, String> tags);
+    MatchedMetricResponse profilingExists(Map<String, String> tags);
 
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceImpl.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.modelservice.service;
 
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 import com.expedia.adaptivealerting.modelservice.repo.MetricProfilingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class MetricProfilingServiceImpl implements MetricProfilingService {
     }
 
     @Override
-    public Boolean profilingExists(Map<String, String> tags) {
+    public MatchedMetricResponse profilingExists(Map<String, String> tags) {
         return metricProfilingRepository.profilingExists(tags);
     }
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileController.java
@@ -16,6 +16,7 @@
 package com.expedia.adaptivealerting.modelservice.web;
 
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 import com.expedia.adaptivealerting.modelservice.service.MetricProfilingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -51,7 +52,7 @@ public class MetricProfileController {
 
     @PostMapping
     @RequestMapping(value = "/search/findByTags")
-    public Boolean profilingExists(@RequestBody Map<String, String> tags) {
+    public MatchedMetricResponse profilingExists(@RequestBody Map<String, String> tags) {
         return metricProfilingService.profilingExists(tags);
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepositoryTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepositoryTest.java
@@ -118,9 +118,9 @@ public class MetricProfilingRepositoryTest {
 
     @Test
     public void testFindMatchingMetricProfiles() {
-        boolean profilingExists = repository.profilingExists(new HashMap<>());
-        assertNotNull(profilingExists);
-        assertEquals(true, profilingExists);
+      //  boolean profilingExists = repository.profilingExists(new HashMap<>());
+     //   assertNotNull(profilingExists);
+     //   assertEquals(true, profilingExists);
     }
 
     @Test(expected = RuntimeException.class)

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepositoryTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/MetricProfilingRepositoryTest.java
@@ -2,6 +2,7 @@ package com.expedia.adaptivealerting.modelservice.repo;
 
 import com.expedia.adaptivealerting.modelservice.dto.common.Expression;
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchClient;
 import com.expedia.adaptivealerting.modelservice.elasticsearch.ElasticSearchProperties;
 import com.expedia.adaptivealerting.modelservice.repo.impl.MetricProfilingRepositoryImpl;
@@ -19,6 +20,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -83,7 +85,6 @@ public class MetricProfilingRepositoryTest {
         indexResponse = mockIndexResponse();
         searchResponse = mockSearchResponse("1");
         this.expression = mom.getExpression();
-
     }
 
     @SneakyThrows
@@ -118,9 +119,9 @@ public class MetricProfilingRepositoryTest {
 
     @Test
     public void testFindMatchingMetricProfiles() {
-      //  boolean profilingExists = repository.profilingExists(new HashMap<>());
-     //   assertNotNull(profilingExists);
-     //   assertEquals(true, profilingExists);
+        MatchedMetricResponse metricResponse = repository.profilingExists(new HashMap<>());
+        assertNotNull(metricResponse);
+        assertEquals("1", metricResponse.getId());
     }
 
     @Test(expected = RuntimeException.class)
@@ -144,13 +145,14 @@ public class MetricProfilingRepositoryTest {
     private SearchResponse mockSearchResponse(String searchIndex) {
         SearchResponse searchResponse = mock(SearchResponse.class);
         Map<String, DocumentField> fields = new HashMap<>();
-        SearchHit searchHit = new SearchHit(101, "xxx", null, fields);
+        SearchHit searchHit = new SearchHit(101, "1", null, fields);
         BytesReference source = new BytesArray("{}");
         searchHit.sourceRef(source);
         SearchHit[] bunchOfSearchHits = new SearchHit[1];
         bunchOfSearchHits[0] = searchHit;
         SearchHits searchHits = new SearchHits(bunchOfSearchHits, 1, 1);
         when(searchResponse.getHits()).thenReturn(searchHits);
+        when(searchResponse.getTook()).thenReturn(new TimeValue(10000));
         return searchResponse;
     }
 }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceTest.java
@@ -1,6 +1,7 @@
 package com.expedia.adaptivealerting.modelservice.service;
 
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 import com.expedia.adaptivealerting.modelservice.repo.MetricProfilingRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,9 +28,12 @@ public class MetricProfilingServiceTest {
     @Mock
     private MetricProfilingRepository repository;
 
+    private MatchedMetricResponse metricResponse;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        initTestObjects();
         initDependencies();
     }
 
@@ -46,16 +50,20 @@ public class MetricProfilingServiceTest {
         verify(profilingService, times(1)).updateMetricProfile("id", true);
     }
 
-  //  @Test
+    @Test
     public void testFindMatchingMetricProfiles() {
-      //  boolean profilingExists = profilingService.profilingExists(new HashMap<>());
-     //   assertNotNull(profilingExists);
-     //   assertEquals(true, profilingExists);
+        MatchedMetricResponse response = profilingService.profilingExists(new HashMap<>());
+        assertNotNull(response);
+        assertEquals("1", response.getId());
+    }
+
+    private void initTestObjects() {
+        this.metricResponse = new MatchedMetricResponse("1", 100L);
     }
 
     private void initDependencies() {
         Mockito.when(repository.createMetricProfile(Mockito.any(CreateMetricProfilingRequest.class))).thenReturn("1");
-       // Mockito.when(repository.profilingExists(Mockito.any(Map.class))).thenReturn(true);
+        Mockito.when(repository.profilingExists(Mockito.any(Map.class))).thenReturn(metricResponse);
     }
 
 }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/MetricProfilingServiceTest.java
@@ -46,16 +46,16 @@ public class MetricProfilingServiceTest {
         verify(profilingService, times(1)).updateMetricProfile("id", true);
     }
 
-    @Test
+  //  @Test
     public void testFindMatchingMetricProfiles() {
-        boolean profilingExists = profilingService.profilingExists(new HashMap<>());
-        assertNotNull(profilingExists);
-        assertEquals(true, profilingExists);
+      //  boolean profilingExists = profilingService.profilingExists(new HashMap<>());
+     //   assertNotNull(profilingExists);
+     //   assertEquals(true, profilingExists);
     }
 
     private void initDependencies() {
         Mockito.when(repository.createMetricProfile(Mockito.any(CreateMetricProfilingRequest.class))).thenReturn("1");
-        Mockito.when(repository.profilingExists(Mockito.any(Map.class))).thenReturn(true);
+       // Mockito.when(repository.profilingExists(Mockito.any(Map.class))).thenReturn(true);
     }
 
 }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileControllerTest.java
@@ -2,6 +2,7 @@ package com.expedia.adaptivealerting.modelservice.web;
 
 import com.expedia.adaptivealerting.modelservice.dto.common.Expression;
 import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.CreateMetricProfilingRequest;
+import com.expedia.adaptivealerting.modelservice.dto.metricprofiling.MatchedMetricResponse;
 import com.expedia.adaptivealerting.modelservice.service.MetricProfilingService;
 import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
 import lombok.val;
@@ -36,6 +37,9 @@ public class MetricProfileControllerTest {
 
     private Expression expression;
 
+    private MatchedMetricResponse metricResponse;
+
+
     @Before
     public void setUp() {
         this.controllerUnderTest = new MetricProfileController();
@@ -47,11 +51,12 @@ public class MetricProfileControllerTest {
     private void initTestObjects() {
         ObjectMother mom = ObjectMother.instance();
         this.expression = mom.getExpression();
+        this.metricResponse = new MatchedMetricResponse("1", 100L);
     }
 
     private void initDependencies() {
         when(profilingService.createMetricProfile(Mockito.any(CreateMetricProfilingRequest.class))).thenReturn("created");
-       // when(profilingService.profilingExists(Mockito.any(Map.class))).thenReturn(true);
+        when(profilingService.profilingExists(Mockito.any(Map.class))).thenReturn(metricResponse);
     }
 
     @Test

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/MetricProfileControllerTest.java
@@ -51,7 +51,7 @@ public class MetricProfileControllerTest {
 
     private void initDependencies() {
         when(profilingService.createMetricProfile(Mockito.any(CreateMetricProfilingRequest.class))).thenReturn("created");
-        when(profilingService.profilingExists(Mockito.any(Map.class))).thenReturn(true);
+       // when(profilingService.profilingExists(Mockito.any(Map.class))).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
Query elastic search in batches to fetch metric profiling info depending on the elastic search latency. This would reduce the load on the elastic search which in turn would also reduce the lag which we may observe in any of the apps in the pipeline.