### PR TITLE
Add trusted flag to detector

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/aggregate/algo/MOfNAggregator.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/aggregate/algo/MOfNAggregator.java
@@ -74,7 +74,8 @@ public class MOfNAggregator implements Aggregator {
         val aggregatedResult = new OutlierDetectorResult()
                 .setAnomalyLevel(result.getAnomalyLevel())
                 .setPredicted(result.getPredicted())
-                .setThresholds(result.getThresholds());
+                .setThresholds(result.getThresholds())
+                .setTrusted(result.isTrusted());
 
         if (numAnomalies() >= config.getM()) {
             aggregatedResult.setAnomalyLevel(AnomalyLevel.STRONG);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/Detector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/Detector.java
@@ -33,6 +33,13 @@ public interface Detector {
     UUID getUuid();
 
     /**
+     * Returns the anomaly detector trust value.
+     *
+     * @return Anomaly detector Trust Level.
+     */
+    boolean isTrusted();
+
+    /**
      * Processes a given metric point.
      *
      * @param metricData Metric data point.

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/DetectorResult.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/DetectorResult.java
@@ -37,5 +37,7 @@ public interface DetectorResult {
      */
     boolean isWarmup();
 
+    boolean isTrusted();
+
     AnomalyLevel getAnomalyLevel();
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorFactoryProvider.java
@@ -32,6 +32,7 @@ public class EdmxDetectorFactoryProvider implements DetectorFactoryProvider<Edmx
         // That's why we're using hyperparameters instead of parameters here.
         val hyperparamsMap = document.getConfig().get("hyperparams");
         val hyperparams = objectMapper.convertValue(hyperparamsMap, EdmxHyperparams.class);
-        return new EdmxDetector(document.getUuid(), hyperparams);
+        val trusted = document.isTrusted();
+        return new EdmxDetector(document.getUuid(), hyperparams, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorResult.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorResult.java
@@ -33,6 +33,12 @@ public class EdmxDetectorResult implements BreakoutDetectorResult {
      */
     private boolean warmup;
 
+
+    /**
+     * Indicates whether the detector is trusted and verified.
+     */
+    private boolean trusted;
+
     /**
      * Estimated breakout timestamp. This is the timestamp for the breakout itself, not the timestamp for when we found
      * the breakout.

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/OutlierDetectorResult.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/OutlierDetectorResult.java
@@ -35,6 +35,7 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OutlierDetectorResult implements DetectorResult {
     private boolean warmup;
+    private boolean trusted;
     private AnomalyLevel anomalyLevel;
 
     /**
@@ -53,6 +54,17 @@ public class OutlierDetectorResult implements DetectorResult {
 
     public OutlierDetectorResult(boolean warmup, AnomalyLevel anomalyLevel) {
         this.warmup = warmup;
+        this.anomalyLevel = anomalyLevel;
+    }
+
+    public OutlierDetectorResult(AnomalyLevel anomalyLevel, boolean trusted) {
+        this.trusted = trusted;
+        this.anomalyLevel = anomalyLevel;
+    }
+
+    public OutlierDetectorResult(boolean warmup, AnomalyLevel anomalyLevel, boolean trusted) {
+        this.warmup = warmup;
+        this.trusted = trusted;
         this.anomalyLevel = anomalyLevel;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetector.java
@@ -39,11 +39,15 @@ public final class ConstantThresholdDetector extends AbstractOutlierDetector {
 
     private final AnomalyClassifier classifier;
 
-    public ConstantThresholdDetector(UUID uuid, ConstantThresholdDetectorParams params) {
+    @Getter
+    private final boolean trusted;
+
+    public ConstantThresholdDetector(UUID uuid, ConstantThresholdDetectorParams params, boolean trusted) {
         super(uuid);
         notNull(params, "params can't be null");
         params.validate();
         this.params = params;
+        this.trusted = trusted;
         this.classifier = new AnomalyClassifier(params.getType());
     }
 
@@ -51,7 +55,12 @@ public final class ConstantThresholdDetector extends AbstractOutlierDetector {
     public DetectorResult detect(MetricData metricData) {
         notNull(metricData, "metricData can't be null");
         val thresholds = params.getThresholds();
+        val trusted = isTrusted();
         val level = classifier.classify(thresholds, metricData.getValue());
-        return new OutlierDetectorResult(level).setThresholds(thresholds);
+        OutlierDetectorResult outlierResult = new OutlierDetectorResult()
+                .setAnomalyLevel(level)
+                .setThresholds(thresholds)
+                .setTrusted(trusted);
+        return outlierResult;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetectorFactoryProvider.java
@@ -30,6 +30,7 @@ public class ConstantThresholdDetectorFactoryProvider implements DetectorFactory
         notNull(document, "document can't be null");
         val paramsMap = document.getConfig().get("params");
         val params = objectMapper.convertValue(paramsMap, ConstantThresholdDetectorParams.class);
-        return new ConstantThresholdDetector(document.getUuid(), params);
+        val trusted = document.isTrusted();
+        return new ConstantThresholdDetector(document.getUuid(), params, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetector.java
@@ -48,6 +48,9 @@ public final class CusumDetector extends AbstractOutlierDetector {
     @Getter
     private CusumDetectorParams params;
 
+    @Getter
+    private boolean trusted;
+
     /**
      * Total number of data points seen so far.
      */
@@ -75,11 +78,12 @@ public final class CusumDetector extends AbstractOutlierDetector {
      */
     private double prevValue = 0.0;
 
-    public CusumDetector(UUID uuid, CusumDetectorParams params) {
+    public CusumDetector(UUID uuid, CusumDetectorParams params, boolean trusted) {
         super(uuid);
         AssertUtil.notNull(params, "params can't be null");
         params.validate();
         this.params = params;
+        this.trusted = trusted;
         this.prevValue = params.getInitMeanEstimate();
     }
 
@@ -88,6 +92,7 @@ public final class CusumDetector extends AbstractOutlierDetector {
         AssertUtil.notNull(metricData, "metricData can't be null");
 
         val params = getParams();
+        val trusted = isTrusted();
         val observed = metricData.getValue();
 
         this.movingRange += Math.abs(this.prevValue - observed);
@@ -161,7 +166,7 @@ public final class CusumDetector extends AbstractOutlierDetector {
             }
         }
 
-        return new OutlierDetectorResult(level);
+        return new OutlierDetectorResult(level, trusted);
     }
 
     private void resetSums() {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetectorFactoryProvider.java
@@ -30,6 +30,7 @@ public class CusumDetectorFactoryProvider implements DetectorFactoryProvider<Cus
         notNull(document, "document can't be null");
         val paramsMap = document.getConfig().get("params");
         val params = objectMapper.convertValue(paramsMap, CusumDetectorParams.class);
-        return new CusumDetector(document.getUuid(), params);
+        val trusted = document.isTrusted();
+        return new CusumDetector(document.getUuid(), params, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/ForecastingDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/ForecastingDetector.java
@@ -66,13 +66,18 @@ public final class ForecastingDetector extends AbstractOutlierDetector {
     @Generated // https://reflectoring.io/100-percent-test-coverage/
     private AnomalyType anomalyType;
 
+    @Getter
+    @Generated // https://reflectoring.io/100-percent-test-coverage/
+    private boolean trusted;
+
     private final AnomalyClassifier classifier;
 
     public ForecastingDetector(
             UUID uuid,
             PointForecaster pointForecaster,
             IntervalForecaster intervalForecaster,
-            AnomalyType anomalyType) {
+            AnomalyType anomalyType,
+            boolean trusted) {
 
         super(uuid);
 
@@ -84,6 +89,7 @@ public final class ForecastingDetector extends AbstractOutlierDetector {
         this.intervalForecaster = intervalForecaster;
         this.anomalyType = anomalyType;
         this.classifier = new AnomalyClassifier(anomalyType);
+        this.trusted = trusted;
     }
 
     @Override
@@ -102,10 +108,12 @@ public final class ForecastingDetector extends AbstractOutlierDetector {
         val thresholds = toAnomalyThresholds(intervalForecast);
         val observed = metricData.getValue();
         val level = classifier.classify(thresholds, observed);
+        val trusted = isTrusted();
 
         return new OutlierDetectorResult(level)
                 .setPredicted(pointForecast.getValue())
-                .setThresholds(thresholds);
+                .setThresholds(thresholds)
+                .setTrusted(trusted);
     }
 
     private AnomalyThresholds toAnomalyThresholds(IntervalForecast intervalForecast) {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyEwmaDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyEwmaDetectorFactoryProvider.java
@@ -46,6 +46,8 @@ public class LegacyEwmaDetectorFactoryProvider implements DetectorFactoryProvide
         val ewma = new EwmaPointForecaster(ewmaParams);
         val welford = new ExponentialWelfordIntervalForecaster(welfordParams);
 
-        return new ForecastingDetector(uuid, ewma, welford, type);
+        val trusted = document.isTrusted();
+
+        return new ForecastingDetector(uuid, ewma, welford, type, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyHoltWintersDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyHoltWintersDetectorFactoryProvider.java
@@ -43,6 +43,8 @@ public class LegacyHoltWintersDetectorFactoryProvider implements DetectorFactory
         val holtWinters = new HoltWintersPointForecaster(holtWintersParams);
         val welford = new ExponentialWelfordIntervalForecaster(welfordParams);
 
-        return new ForecastingDetector(uuid, holtWinters, welford, type);
+        val trusted = document.isTrusted();
+
+        return new ForecastingDetector(uuid, holtWinters, welford, type, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyPewmaDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/LegacyPewmaDetectorFactoryProvider.java
@@ -43,6 +43,8 @@ public class LegacyPewmaDetectorFactoryProvider implements DetectorFactoryProvid
         val pewma = new PewmaPointForecaster(pewmaParams);
         val welford = new ExponentialWelfordIntervalForecaster(welfordParams);
 
-        return new ForecastingDetector(uuid, pewma, welford, type);
+        val trusted = document.isTrusted();
+
+        return new ForecastingDetector(uuid, pewma, welford, type, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetector.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetector.java
@@ -57,6 +57,9 @@ public final class IndividualsDetector implements Detector {
     private UUID uuid;
 
     @Getter
+    private boolean trusted;
+
+    @Getter
     private IndividualsDetectorParams params;
 
     /**
@@ -107,11 +110,12 @@ public final class IndividualsDetector implements Detector {
      */
     private double mean;
 
-    public IndividualsDetector(UUID uuid, IndividualsDetectorParams params) {
+    public IndividualsDetector(UUID uuid, IndividualsDetectorParams params, boolean trusted) {
         notNull(uuid, "uuid can't be null");
         notNull(params, "params can't be null");
         params.validate();
         this.uuid = uuid;
+        this.trusted = trusted;
         this.params = params;
         this.prevValue = params.getInitValue();
         this.target = params.getInitValue();
@@ -123,6 +127,7 @@ public final class IndividualsDetector implements Detector {
         notNull(metricData, "metricData can't be null");
 
         val params = getParams();
+        val trusted = isTrusted();
 
         val observed = metricData.getValue();
         val stdDev = sqrt(this.variance);
@@ -175,6 +180,7 @@ public final class IndividualsDetector implements Detector {
         final OutlierDetectorResult result = new OutlierDetectorResult(level);
         result.setPredicted(this.mean);
         result.setThresholds(thresholds);
+        result.setTrusted(trusted);
         return result;
     }
 

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorFactoryProvider.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorFactoryProvider.java
@@ -30,6 +30,7 @@ public class IndividualsDetectorFactoryProvider implements DetectorFactoryProvid
         notNull(document, "document can't be null");
         val paramsMap = document.getConfig().get("params");
         val params = objectMapper.convertValue(paramsMap, IndividualsDetectorParams.class);
-        return new IndividualsDetector(document.getUuid(), params);
+        val trusted = document.isTrusted();
+        return new IndividualsDetector(document.getUuid(), params, trusted);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorDocument.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorDocument.java
@@ -37,6 +37,7 @@ public class DetectorDocument {
     private UUID uuid;
     private String type;
     private boolean enabled;
+    private boolean trusted;
 
     @JsonProperty("detectorConfig")
     private Map<String, Object> config;

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/aggregate/algo/MOfNAggregatorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/aggregate/algo/MOfNAggregatorTest.java
@@ -35,19 +35,23 @@ public final class MOfNAggregatorTest {
         this.normalResult = new OutlierDetectorResult()
                 .setAnomalyLevel(AnomalyLevel.NORMAL)
                 .setPredicted(42.2)
-                .setThresholds(new AnomalyThresholds(100.0, 90.0, 20.0, 10.0));
+                .setThresholds(new AnomalyThresholds(100.0, 90.0, 20.0, 10.0))
+                .setTrusted(true);
         this.weakResult = new OutlierDetectorResult()
                 .setAnomalyLevel(AnomalyLevel.WEAK)
                 .setPredicted(95.1)
-                .setThresholds(new AnomalyThresholds(102.0, 92.0, 22.0, 12.0));
+                .setThresholds(new AnomalyThresholds(102.0, 92.0, 22.0, 12.0))
+                .setTrusted(true);
         this.strongResult = new OutlierDetectorResult()
                 .setAnomalyLevel(AnomalyLevel.STRONG)
                 .setPredicted(105.8)
-                .setThresholds(new AnomalyThresholds(101.0, 91.0, 21.0, 11.0));
+                .setThresholds(new AnomalyThresholds(101.0, 91.0, 21.0, 11.0))
+                .setTrusted(true);
         this.warmupResult = new OutlierDetectorResult()
                 .setAnomalyLevel(AnomalyLevel.MODEL_WARMUP)
                 .setPredicted(37.2)
-                .setThresholds(new AnomalyThresholds(103.0, 93.0, 23.0, 13.0));
+                .setThresholds(new AnomalyThresholds(103.0, 93.0, 23.0, 13.0))
+                .setTrusted(true);
     }
 
     @Test
@@ -64,6 +68,7 @@ public final class MOfNAggregatorTest {
         assertEquals(AnomalyLevel.NORMAL, aggregatedResult.getAnomalyLevel());
         assertEquals(normalResult.getPredicted(), aggregatedResult.getPredicted());
         assertEquals(normalResult.getThresholds(), aggregatedResult.getThresholds());
+        assertEquals(normalResult.isTrusted(), aggregatedResult.isTrusted());
     }
 
     @Test
@@ -73,6 +78,7 @@ public final class MOfNAggregatorTest {
         assertEquals(AnomalyLevel.WEAK, aggregatedResult.getAnomalyLevel());
         assertEquals(weakResult.getPredicted(), aggregatedResult.getPredicted());
         assertEquals(weakResult.getThresholds(), aggregatedResult.getThresholds());
+        assertEquals(normalResult.isTrusted(), aggregatedResult.isTrusted());
     }
 
     @Test

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/breakout/algo/edmx/EdmxDetectorTest.java
@@ -48,7 +48,8 @@ public final class EdmxDetectorTest {
                 .setNumPerms(199)
                 .setStrongAlpha(0.01)
                 .setWeakAlpha(0.05);
-        val detectorUnderTest = new EdmxDetector(UUID.randomUUID(), hyperparams);
+        val trusted = true;
+        val detectorUnderTest = new EdmxDetector(UUID.randomUUID(), hyperparams, trusted);
 
         val metricDef = TestObjectMother.metricDefinition();
         val is = ClassLoader.getSystemResourceAsStream("datasets/white-noise-with-breakout-at-row-600.csv");

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/OutlierDetectorResultTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/OutlierDetectorResultTest.java
@@ -38,5 +38,26 @@ public final class OutlierDetectorResultTest {
         assertEquals(AnomalyLevel.STRONG, anomalyResult2.getAnomalyLevel());
         assertEquals(10.0, anomalyResult2.getPredicted(), TOLERANCE);
         assertNotNull(anomalyResult2.getThresholds());
+
+        // Test constructor for anomalyLevel, trusted
+        val anomalyResult3 = new OutlierDetectorResult(AnomalyLevel.STRONG, true);
+        anomalyResult3.setPredicted(10.0);
+        anomalyResult3.setThresholds(new AnomalyThresholds(100.0, null, null, null));
+
+        assertEquals(AnomalyLevel.STRONG, anomalyResult3.getAnomalyLevel());
+        assertEquals(true, anomalyResult3.isTrusted());
+        assertEquals(10.0, anomalyResult3.getPredicted(), TOLERANCE);
+        assertNotNull(anomalyResult3.getThresholds());
+
+        // Test constructor for warmup, anomalyLevel, trusted
+        val anomalyResult4 = new OutlierDetectorResult(true, AnomalyLevel.STRONG, true);
+        anomalyResult4.setPredicted(10.0);
+        anomalyResult4.setThresholds(new AnomalyThresholds(100.0, null, null, null));
+
+        assertEquals(AnomalyLevel.STRONG, anomalyResult4.getAnomalyLevel());
+        assertEquals(true, anomalyResult4.isTrusted());
+        assertEquals(true, anomalyResult4.isWarmup());
+        assertEquals(10.0, anomalyResult4.getPredicted(), TOLERANCE);
+        assertNotNull(anomalyResult4.getThresholds());
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/constant/ConstantThresholdDetectorTest.java
@@ -42,6 +42,7 @@ public class ConstantThresholdDetectorTest {
     private UUID detectorUuid;
     private MetricDefinition metricDefinition;
     private long epochSecond;
+    private boolean trusted;
 
     @Mock
     private AnomalyThresholds thresholds;
@@ -56,7 +57,7 @@ public class ConstantThresholdDetectorTest {
 
     @Test
     public void testAccessors() {
-        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED);
+        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED, trusted);
         assertEquals(detectorUuid, detector.getUuid());
         assertSame(thresholds, detector.getParams().getThresholds());
     }
@@ -64,7 +65,7 @@ public class ConstantThresholdDetectorTest {
     @Test
     public void testEvaluateLeftTailed_positiveThresholds() {
         val thresholds = new AnomalyThresholds(null, null, 300.0, 100.0);
-        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED);
+        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED, trusted);
         verifyResult(AnomalyLevel.NORMAL, detector, epochSecond, 500.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, 300.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, 200.0);
@@ -75,7 +76,7 @@ public class ConstantThresholdDetectorTest {
     @Test
     public void testEvaluateLeftTailed_negativeThresholds() {
         val thresholds = new AnomalyThresholds(null, null, -10.0, -30.0);
-        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED);
+        val detector = detector(detectorUuid, thresholds, AnomalyType.LEFT_TAILED, trusted);
         verifyResult(AnomalyLevel.NORMAL, detector, epochSecond, 1.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, -10.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, -15.0);
@@ -86,7 +87,7 @@ public class ConstantThresholdDetectorTest {
     @Test
     public void testEvaluateRightTailed_positiveThresholds() {
         val thresholds = new AnomalyThresholds(300.0, 200.0, null, null);
-        val detector = detector(detectorUuid, thresholds, AnomalyType.RIGHT_TAILED);
+        val detector = detector(detectorUuid, thresholds, AnomalyType.RIGHT_TAILED, trusted);
         verifyResult(AnomalyLevel.NORMAL, detector, epochSecond, 100.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, 200.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, 220.0);
@@ -97,7 +98,7 @@ public class ConstantThresholdDetectorTest {
     @Test
     public void testEvaluateRightTailed_negativeThresholds() {
         val thresholds = new AnomalyThresholds(-100.0, -300.0, null, null);
-        val detector = detector(detectorUuid, thresholds, AnomalyType.RIGHT_TAILED);
+        val detector = detector(detectorUuid, thresholds, AnomalyType.RIGHT_TAILED, trusted);
         verifyResult(AnomalyLevel.NORMAL, detector, epochSecond, -1000.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, -300.0);
         verifyResult(AnomalyLevel.WEAK, detector, epochSecond, -250.0);
@@ -105,11 +106,11 @@ public class ConstantThresholdDetectorTest {
         verifyResult(AnomalyLevel.STRONG, detector, epochSecond, 0.0);
     }
 
-    private ConstantThresholdDetector detector(UUID uuid, AnomalyThresholds thresholds, AnomalyType type) {
+    private ConstantThresholdDetector detector(UUID uuid, AnomalyThresholds thresholds, AnomalyType type, boolean trusted) {
         val params = new ConstantThresholdDetectorParams()
                 .setThresholds(thresholds)
                 .setType(type);
-        return new ConstantThresholdDetector(uuid, params);
+        return new ConstantThresholdDetector(uuid, params, trusted);
     }
 
     private void verifyResult(AnomalyLevel level, Detector detector, long epochSecond, double value) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/cusum/CusumDetectorTest.java
@@ -61,6 +61,7 @@ public class CusumDetectorTest {
     @Test
     public void testClassify_leftTailed() {
         val anomalyType = AnomalyType.LEFT_TAILED;
+        val trusted = true;
 
         val params = new CusumDetectorParams()
                 .setType(anomalyType)
@@ -77,7 +78,7 @@ public class CusumDetectorTest {
                 new CusumDetectorTestRow(990.0, AnomalyLevel.STRONG.name()),
         };
 
-        testClassify(params, anomalyType, testRows);
+        testClassify(params, anomalyType, testRows, trusted);
     }
 
     @Test
@@ -86,6 +87,7 @@ public class CusumDetectorTest {
         val testRow0 = testRows.next();
 
         val anomalyType = AnomalyType.RIGHT_TAILED;
+        val trusted = true;
 
         val params = new CusumDetectorParams()
                 .setType(anomalyType)
@@ -96,7 +98,7 @@ public class CusumDetectorTest {
                 .setInitMeanEstimate(testRow0.getObserved())
                 .setWarmUpPeriod(WARMUP_PERIOD);
 
-        val detector = new CusumDetector(detectorUuid, params);
+        val detector = new CusumDetector(detectorUuid, params, trusted);
 
         int numDataPoints = 1;
 
@@ -122,6 +124,7 @@ public class CusumDetectorTest {
     @Test
     public void testClassify_twoTailed() {
         val anomalyType = AnomalyType.TWO_TAILED;
+        val trusted = true;
 
         val params = new CusumDetectorParams()
                 .setType(anomalyType)
@@ -139,11 +142,11 @@ public class CusumDetectorTest {
                 new CusumDetectorTestRow(960.0, AnomalyLevel.WEAK.name()),
         };
 
-        testClassify(params, anomalyType, testRows);
+        testClassify(params, anomalyType, testRows, trusted);
     }
 
-    private void testClassify(CusumDetectorParams params, AnomalyType anomalyType, CusumDetectorTestRow[] testRows) {
-        val detector = new CusumDetector(detectorUuid, params);
+    private void testClassify(CusumDetectorParams params, AnomalyType anomalyType, CusumDetectorTestRow[] testRows, boolean trusted) {
+        val detector = new CusumDetector(detectorUuid, params, trusted);
         assertEquals(detectorUuid, detector.getUuid());
         assertSame(params, detector.getParams());
 
@@ -165,6 +168,7 @@ public class CusumDetectorTest {
             val anomalyResult = (OutlierDetectorResult) detector.detect(metricData);
             val anomalyLevel = anomalyResult.getAnomalyLevel();
             assertEquals(AnomalyLevel.valueOf(testRow.getLevel()), anomalyLevel);
+            assertEquals(anomalyResult.isTrusted(), trusted);
         }
     }
 

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/ForecastingDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/forecasting/ForecastingDetectorTest.java
@@ -52,6 +52,7 @@ public class ForecastingDetectorTest {
 
     private UUID detectorUuid;
     private AnomalyType anomalyType;
+    private boolean trusted;
 
     @Before
     public void setUp() {
@@ -59,8 +60,9 @@ public class ForecastingDetectorTest {
         initDependencies();
         this.detectorUuid = UUID.randomUUID();
         this.anomalyType = AnomalyType.TWO_TAILED;
+        this.trusted = true;
         this.detectorUnderTest =
-                new ForecastingDetector(detectorUuid, pointForecaster, intervalForecaster, anomalyType);
+                new ForecastingDetector(detectorUuid, pointForecaster, intervalForecaster, anomalyType, trusted);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class ForecastingDetectorTest {
         assertEquals(pointForecaster, detectorUnderTest.getPointForecaster());
         assertEquals(intervalForecaster, detectorUnderTest.getIntervalForecaster());
         assertEquals(anomalyType, detectorUnderTest.getAnomalyType());
+        assertEquals(trusted, detectorUnderTest.isTrusted());
     }
 
     @Test

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorFactoryProviderTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorFactoryProviderTest.java
@@ -31,8 +31,10 @@ public class IndividualsDetectorFactoryProviderTest extends AbstractDetectorFact
         val document = readDocument("individuals");
         val detector = factoryUnderTest.buildDetector(document);
         val params = detector.getParams();
+        val trusted = detector.isTrusted();
 
         assertNotNull(detector);
+        assertEquals(true, trusted);
         assertEquals(IndividualsDetector.class, detector.getClass());
         assertEquals("a6a4d8c4-4102-51fc-a1c7-38aa6f066cca", detector.getUuid().toString());
         assertEquals(3.0, params.getStrongSigmas(), TOLERANCE);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/detect/outlier/algo/individuals/IndividualsDetectorTest.java
@@ -44,6 +44,7 @@ public class IndividualsDetectorTest {
     private MetricDefinition metricDef;
     private long epochSecond;
     private static List<IndividualsDetectorTestRow> data;
+    private boolean trusted;
 
 
     @BeforeClass
@@ -56,6 +57,7 @@ public class IndividualsDetectorTest {
         this.detectorUuid = UUID.randomUUID();
         this.metricDef = new MetricDefinition("some-key");
         this.epochSecond = Instant.now().getEpochSecond();
+        this.trusted = true;
     }
 
     @Test
@@ -67,9 +69,10 @@ public class IndividualsDetectorTest {
         val params = new IndividualsDetectorParams()
                 .setInitValue(observed0)
                 .setWarmUpPeriod(WARMUP_PERIOD);
-        val detector = new IndividualsDetector(detectorUuid, params);
+        val detector = new IndividualsDetector(detectorUuid, params, trusted);
 
         assertEquals(detectorUuid, detector.getUuid());
+        assertEquals(trusted, detector.isTrusted());
         assertSame(params, detector.getParams());
 
         int noOfDataPoints = 1;

--- a/anomdetect/src/test/resources/detector-documents/constant-threshold-invalid-params.json
+++ b/anomdetect/src/test/resources/detector-documents/constant-threshold-invalid-params.json
@@ -2,6 +2,7 @@
   "uuid": "e2e290a0-d1c1-471e-9d72-79d43282cfbd",
   "type": "constant-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/constant-threshold-invalid-uuid.json
+++ b/anomdetect/src/test/resources/detector-documents/constant-threshold-invalid-uuid.json
@@ -2,6 +2,7 @@
   "uuid": "invalid-uuid",
   "type": "constant-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/constant-threshold.json
+++ b/anomdetect/src/test/resources/detector-documents/constant-threshold.json
@@ -2,6 +2,7 @@
   "uuid": "e2e290a0-d1c1-471e-9d72-79d43282cfbd",
   "type": "constant-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/cusum.json
+++ b/anomdetect/src/test/resources/detector-documents/cusum.json
@@ -2,6 +2,7 @@
   "uuid": "3ec81aa2-2cdc-415e-b4f3-c1beb223ae60",
   "type": "cusum-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/edmx-invalid-hyperparams.json
+++ b/anomdetect/src/test/resources/detector-documents/edmx-invalid-hyperparams.json
@@ -2,6 +2,7 @@
   "uuid": "9d934a88-f89b-4793-956a-bede72c3081f",
   "type": "edmx-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/edmx-invalid-uuid.json
+++ b/anomdetect/src/test/resources/detector-documents/edmx-invalid-uuid.json
@@ -2,6 +2,7 @@
   "uuid": "invalid-uuid",
   "type": "edmx-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/edmx.json
+++ b/anomdetect/src/test/resources/detector-documents/edmx.json
@@ -2,6 +2,7 @@
   "uuid": "9d934a88-f89b-4793-956a-bede72c3081f",
   "type": "edmx-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/ewma.json
+++ b/anomdetect/src/test/resources/detector-documents/ewma.json
@@ -2,6 +2,7 @@
   "uuid": "3e047348-f837-f615-271c-dce6206f50d6",
   "type": "ewma-detector",
   "enabled": false,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/holt-winters.json
+++ b/anomdetect/src/test/resources/detector-documents/holt-winters.json
@@ -2,6 +2,7 @@
   "uuid": "a63c2128-113a-8fd7-942d-f8ae228b61b0",
   "type": "holtwinters-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/individuals.json
+++ b/anomdetect/src/test/resources/detector-documents/individuals.json
@@ -2,6 +2,7 @@
   "uuid": "a6a4d8c4-4102-51fc-a1c7-38aa6f066cca",
   "type": "individuals-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/invalid-type.json
+++ b/anomdetect/src/test/resources/detector-documents/invalid-type.json
@@ -2,6 +2,7 @@
   "uuid": "c8d4d8c4-8068-46bf-a1c7-43ea6f066eeb",
   "type": "invalid-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/pewma.json
+++ b/anomdetect/src/test/resources/detector-documents/pewma.json
@@ -2,6 +2,7 @@
   "uuid": "6ec81aa2-2cdc-415e-b4f3-c1beb223ae60",
   "type": "pewma-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/anomdetect/src/test/resources/detector-documents/rcf.json
+++ b/anomdetect/src/test/resources/detector-documents/rcf.json
@@ -2,6 +2,7 @@
   "uuid": "c8d4d8c4-8068-46bf-a1c7-43ea6f066eeb",
   "type": "rcf-detector",
   "enabled": true,
+  "trusted": true,
   "meta": {
     "dateCreated": "2019-10-16T17:08:40Z",
     "dateUpdated": "2019-10-16T17:08:40Z",

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,6 +1,6 @@
 # Testing the Adaptive Alerting pipeline with Docker Compose
 
-The Docker Compose setup allows you run the Adaptive Alerting components and test sample metrics against the project. You can begin by building the project's docker images through the Makefile. You can also subsitute previous versions by updating the docker-compose.yml file and referencing images from Docker Hub.
+The Docker Compose setup allows you run the Adaptive Alerting components and test sample metrics against the project. You can begin by building the project's docker images through the Makefile. You can also substitute previous versions by updating the docker-compose.yml file and referencing images from Docker Hub.
 
 #### 1. Build project images locally (From adaptive-alerting directory)
 ```

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,13 +1,18 @@
 # Testing the Adaptive Alerting pipeline with Docker Compose
 
-The Docker Compose setup allows you run the Adaptive Alerting components and test sample metrics against the project. By default the images are downloaded from Docker Hub, but they can be substituted with your own builds or different versions from Docker Hub for testing purposes.
+The Docker Compose setup allows you run the Adaptive Alerting components and test sample metrics against the project. You can begin by building the project's docker images through the Makefile. You can also subsitute previous versions by updating the docker-compose.yml file and referencing images from Docker Hub.
 
-#### 1. Build and run using Docker Compose
+#### 1. Build project images locally (From adaptive-alerting directory)
+```
+make clean build docker_build
+```
+
+#### 2. Run images using Docker Compose (From adaptive-alerting/docker-compose directory)
 ```
 docker-compose up
 ```
 
-#### 2. Send sample events to running environment
+#### 3. Send sample events to running environment
 Wait a few minutes for docker-compose to finish and all the services to come up before executing `send-sample-metrics.py`. If no anomalies are generated it could be because the sample detector has not yet been inserted.
 ```
 python3 send-sample-metrics.py
@@ -15,7 +20,7 @@ python3 send-sample-metrics.py
 
 **Note**: This Python script sends randomized sample metrics into the intake Kafka topic and show any anomalous values. Anomalies are determined by the sample constant threshold detector and detector mapping that is populated upon bringing up docker-compose. Requires: [msgpack](https://msgpack.org/index.html) and [kafka-python](https://kafka-python.readthedocs.io/en/master/) libraries.
 
-#### 3. Reset Docker Compose and remove data volumes
+#### 4. Reset Docker Compose and remove data volumes
 ```
 docker-compose down -v
 ```

--- a/docker-compose/scripts/populate-es.sh
+++ b/docker-compose/scripts/populate-es.sh
@@ -14,9 +14,6 @@
 #       See the License for the specific language governing permissions and
 #       limitations under the License.
 
-now=$(date -u +"%Y-%m-%d %H:%M:%S")
-#uuid=$(python -c 'import sys,uuid; sys.stdout.write(str(uuid.uuid4()))')
-
 echo "--- Waiting for the Model Service API to become available before inserting sample detector and mapping..."
 
 # Do not post sample detector to API until elasticsearch indexes pre-created by the modelservice
@@ -34,7 +31,6 @@ until detectoruuid=$(curl -s -X POST \
     -d '{
             "createdBy": "sampleuser",
             "type": "constant-detector",
-            "lastUpdateTimestamp": "'"$now"'",
             "detectorConfig": {
                 "hyperparams": {
                     "strategy": "percentile",
@@ -50,7 +46,8 @@ until detectoruuid=$(curl -s -X POST \
                     }
                 }
             },
-            "enabled": true
+            "enabled": true,
+            "trusted": true
             }')
 do
     sleep 1

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
@@ -41,6 +41,8 @@ public interface DetectorRepository {
 
     void toggleDetector(String uuid, Boolean enabled);
 
+    void trustDetector(String uuid, Boolean trusted);
+
     List<DetectorDocument> getLastUpdatedDetectors(long interval);
 
     List<DetectorDocument> getLastUpdatedDetectors(String fromDate, String toDate);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImpl.java
@@ -89,6 +89,9 @@ public class DetectorRepositoryImpl implements DetectorRepository {
         } else {
             DetectorDocument.Meta metaBlock = document.getMeta();
             metaBlock.setDateCreated(nowDate);
+            if (metaBlock.getCreatedBy() == null) {
+                metaBlock.setCreatedBy(document.getCreatedBy());
+            }
         }
 
         // Do this after setting the UUID since validation checks for the UUID.

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -69,6 +69,14 @@ public class DetectorController {
         detectorRepo.toggleDetector(uuid, enabled);
     }
 
+    @PostMapping(path = "/trustDetector", consumes = "application/json", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public void trustDetector(@RequestParam String uuid, @RequestParam Boolean trusted) {
+        Assert.notNull(uuid, "uuid can't be null");
+        Assert.notNull(trusted, "trusted can't be null");
+        detectorRepo.trustDetector(uuid, trusted);
+    }
+
     @GetMapping(path = "/getLastUpdatedDetectors", produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
     public List<DetectorDocument> getLastUpdatedDetectors(@RequestParam long interval) {

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
@@ -145,7 +145,7 @@ public class DetectorRepositoryImplTest {
         val mom = ObjectMother.instance();
         val document = mom.getDetectorDocument();
         document.setMeta(null);
-        UUID actualUuid = repoUnderTest.createDetector(document);
+        repoUnderTest.createDetector(document);
     }
 
     @Test

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
@@ -232,6 +232,13 @@ public class DetectorRepositoryImplTest {
         verify(detectorRepository, times(1)).toggleDetector("aeb4d849-847a-45c0-8312-dc0fcf22b639", true);
     }
 
+
+    @Test(expected = RuntimeException.class)
+    public void trustDetectorFail() throws IOException {
+        Mockito.when(elasticSearchClient.update(any(UpdateRequest.class), any(RequestOptions.class))).thenThrow(new IOException());
+        repoUnderTest.trustDetector("aeb4d849-847a-45c0-8312-dc0fcf22b639", true);
+    }
+
     @Test
     public void testTrustDetector() {
         DetectorRepository detectorRepository = mock(DetectorRepository.class);

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
@@ -149,6 +149,26 @@ public class DetectorRepositoryImplTest {
     }
 
     @Test
+    public void testCreateDetector_populatedMeta() {
+        val mom = ObjectMother.instance();
+        val document = mom.getDetectorDocument();
+        DetectorDocument.Meta metaBlock = new DetectorDocument.Meta();
+        metaBlock.setCreatedBy("user");
+        document.setMeta(metaBlock);
+        repoUnderTest.createDetector(document);
+    }
+
+    @Test
+    public void testCreateDetector_populatedMeta_noUser() {
+        val mom = ObjectMother.instance();
+        val document = mom.getDetectorDocument();
+        DetectorDocument.Meta metaBlock = new DetectorDocument.Meta();
+        metaBlock.setCreatedBy(null);
+        document.setMeta(metaBlock);
+        repoUnderTest.createDetector(document);
+    }
+
+    @Test
     public void testFindByUuid() {
         DetectorDocument actualDetector = repoUnderTest.findByUuid("uuid");
         assertNotNull(actualDetector);

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/repo/impl/DetectorRepositoryImplTest.java
@@ -141,12 +141,21 @@ public class DetectorRepositoryImplTest {
     }
 
     @Test
+    public void testCreateDetector_emptyMeta() {
+        val mom = ObjectMother.instance();
+        val document = mom.getDetectorDocument();
+        document.setMeta(null);
+        UUID actualUuid = repoUnderTest.createDetector(document);
+    }
+
+    @Test
     public void testFindByUuid() {
         DetectorDocument actualDetector = repoUnderTest.findByUuid("uuid");
         assertNotNull(actualDetector);
         Assert.assertEquals(UUID.fromString("aeb4d849-847a-45c0-8312-dc0fcf22b639"), actualDetector.getUuid());
         Assert.assertEquals("test-user", actualDetector.getCreatedBy());
         Assert.assertEquals(true, actualDetector.isEnabled());
+        Assert.assertEquals(true, actualDetector.isTrusted());
     }
 
     @Test
@@ -204,6 +213,14 @@ public class DetectorRepositoryImplTest {
     }
 
     @Test
+    public void testTrustDetector() {
+        DetectorRepository detectorRepository = mock(DetectorRepository.class);
+        doNothing().when(detectorRepository).trustDetector(anyString(), anyBoolean());
+        detectorRepository.trustDetector("aeb4d849-847a-45c0-8312-dc0fcf22b639", true);
+        verify(detectorRepository, times(1)).trustDetector("aeb4d849-847a-45c0-8312-dc0fcf22b639", true);
+    }
+
+    @Test
     public void testDeleteDetector() {
         val detectorRepository = mock(DetectorRepository.class);
         doNothing().when(detectorRepository).deleteDetector(anyString());
@@ -253,7 +270,7 @@ public class DetectorRepositoryImplTest {
         SearchResponse searchResponse = mock(SearchResponse.class);
         Map<String, DocumentField> fields = new HashMap<>();
         SearchHit searchHit = new SearchHit(101, "xxx", null, fields);
-        BytesReference source = new BytesArray("{\"uuid\":\"13456565\",\"createdBy\":\"user\",\"lastUpdateTimestamp\":\"2019-05-20 12:00:00\",\"enabled\":true,\"detectorConfig\":{\"hyperparams\":{\"alpha\":0.5,\"beta\":0.6},\"trainingMetaData\":{\"alpha\":0.5},\"params\":{\"upperWeak\":123}}}}");
+        BytesReference source = new BytesArray("{\"uuid\":\"13456565\",\"createdBy\":\"user\",\"lastUpdateTimestamp\":\"2019-05-20 12:00:00\",\"enabled\":true,\"trusted\":true,\"detectorConfig\":{\"hyperparams\":{\"alpha\":0.5,\"beta\":0.6},\"trainingMetaData\":{\"alpha\":0.5},\"params\":{\"upperWeak\":123}}}}");
         searchHit.sourceRef(source);
         SearchHit[] bunchOfSearchHits = new SearchHit[1];
         bunchOfSearchHits[0] = searchHit;
@@ -288,7 +305,7 @@ public class DetectorRepositoryImplTest {
     private GetResponse mockGetResponse(String id) {
         GetResponse getResponse = mock(GetResponse.class);
         Map<String, DocumentField> fields = new HashMap<>();
-        String source = "{\"uuid\":\"aeb4d849-847a-45c0-8312-dc0fcf22b639\",\"createdBy\":\"test-user\",\"lastUpdateTimestamp\":\"2019-05-20 12:00:00\",\"enabled\":true,\"detectorConfig\":{\"hyperparams\":{\"alpha\":0.5,\"beta\":0.6},\"trainingMetaData\":{\"alpha\":0.5},\"params\":{\"upperWeak\":123}}}}";
+        String source = "{\"uuid\":\"aeb4d849-847a-45c0-8312-dc0fcf22b639\",\"createdBy\":\"test-user\",\"lastUpdateTimestamp\":\"2019-05-20 12:00:00\",\"enabled\":true,\"trusted\":true,\"detectorConfig\":{\"hyperparams\":{\"alpha\":0.5,\"beta\":0.6},\"trainingMetaData\":{\"alpha\":0.5},\"params\":{\"upperWeak\":123}}}}";
         when(getResponse.getSourceAsString()).thenReturn(source);
         when(getResponse.getId()).thenReturn(id);
         return getResponse;
@@ -299,5 +316,6 @@ public class DetectorRepositoryImplTest {
         Assert.assertEquals(UUID.fromString("aeb4d849-847a-45c0-8312-dc0fcf22b639"), actualDetectors.get(0).getUuid());
         Assert.assertEquals("test-user", actualDetectors.get(0).getCreatedBy());
         Assert.assertEquals(true, actualDetectors.get(0).isEnabled());
+        Assert.assertEquals(true, actualDetectors.get(0).isTrusted());
     }
 }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
@@ -116,6 +116,7 @@ public class ObjectMother {
                 .setCreatedBy("test-user")
                 .setConfig(new HashMap<>())
                 .setEnabled(true)
+                .setTrusted(true)
                 .setLastUpdateTimestamp(DateUtil.toUtcDate("2019-04-06 22:00:00"));
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -91,6 +91,11 @@ public class DetectorControllerTest {
     }
 
     @Test
+    public void testTrustDetector() {
+        controllerUnderTest.trustDetector(someUuid.toString(), true);
+    }
+
+    @Test
     public void testDeleteDetector() {
         val someUuidStr = someUuid.toString();
         controllerUnderTest.deleteDetector(someUuidStr);


### PR DESCRIPTION
- Adds new trusted flag as an indicator on the output anomalies wether the detector is one that has been verified and trusted as valid. 
- New API allows enabling/disabling trusted flag by detector uuid.
- Updated Create Detector and Toggle Detector APIs to modify metadata and properly set last updated time.
