### PR TITLE
Update deployment_yaml.tpl

### DIFF
--- a/deployment/terraform/aa-metric-functions/templates/deployment_yaml.tpl
+++ b/deployment/terraform/aa-metric-functions/templates/deployment_yaml.tpl
@@ -66,9 +66,9 @@ spec:
       initContainers:
       - name: download-input-file
         # example - image: busybox
-        image: "${initContainer_image}"
+        image: ${initContainer_image}
         # example - command: ["sh", "-c", "curl", "<input-file-location>", "-o", "/config/functions.txt"]
-        command: "${download_input_file_command}"
+        command: ${download_input_file_command}
         volumeMounts:
         - mountPath:  /config
           name: functions-volume


### PR DESCRIPTION
fix bug with double quotes for image variable for initContainer at aa-metric-functions