### PR TITLE
Fix CustomExceptionHandler.handleRecordNotFound()

### DIFF
--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/exception/CustomExceptionHandler.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/exception/CustomExceptionHandler.java
@@ -45,7 +45,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public final ResponseEntity<Object> handleAllExceptions(Exception ex) {
+    public ResponseEntity<Object> handleAllExceptions(Exception ex) {
         List<String> details = new ArrayList<>();
         details.add(ex.getLocalizedMessage());
         ErrorResponse error = new ErrorResponse("Server Error", details);
@@ -56,10 +56,12 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(value = {RecordNotFoundException.class})
-    protected ResponseEntity<Object> handleRecordNotFound(final RuntimeException ex, final WebRequest request) {
+    public ResponseEntity<Object> handleRecordNotFound(final RuntimeException ex, final WebRequest request) {
         return handleExceptionInternal(ex, ex.getMessage(), new HttpHeaders(), HttpStatus.NOT_FOUND, request);
     }
 
+    // TODO: We should return 404 (NOT_FOUND) when invalid parameters are supplied.
+    // TODO:   400 (BAD_REQUEST) should be reserved for when a malformed path is supplied (i.e. when the request should not be retried later)
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<Object> handleIllegalArgument(final RuntimeException ex, final WebRequest request) {
         return handleExceptionInternal(ex, ex.getMessage(), new HttpHeaders(), HttpStatus.BAD_REQUEST, request);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/AnomalyController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/AnomalyController.java
@@ -37,6 +37,7 @@ public class AnomalyController {
     public List<OutlierDetectorResult> getAnomalies(@RequestBody AnomalyRequest request) {
         List<OutlierDetectorResult> detectorResults = anomalyRepository.getAnomalies(request);
         if (detectorResults == null || detectorResults.isEmpty()) {
+            // TODO: This should be RecordNotFoundException
             throw new IllegalArgumentException("Invalid request: " + request);
         }
         return detectorResults;

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -64,6 +64,7 @@ public class DetectorController {
     public List<DetectorDocument> findByCreatedBy(@RequestParam String user) {
         List<DetectorDocument> detectors = detectorRepo.findByCreatedBy(user);
         if (detectors == null || detectors.isEmpty()) {
+            // TODO: This should be RecordNotFoundException
             throw new IllegalArgumentException("Invalid user: " + user);
         }
         return detectors;

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/CustomExceptionHandlerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/CustomExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.web;
+
+import com.expedia.adaptivealerting.modelservice.exception.CustomExceptionHandler;
+import com.expedia.adaptivealerting.modelservice.repo.DetectorRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest
+public class CustomExceptionHandlerTest {
+
+    private static final String DUMMY_USER = "Dummy User";
+
+    @InjectMocks
+    private DetectorController controllerUnderTest;
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private DetectorRepository detectorRepo;
+
+    private UUID someUuid;
+
+    @Before
+    public void setUp() {
+        this.controllerUnderTest = new DetectorController();
+        mockMvc = MockMvcBuilders.standaloneSetup(controllerUnderTest)
+                .setControllerAdvice(new CustomExceptionHandler(new SimpleMeterRegistry()))
+                .build();
+
+        MockitoAnnotations.initMocks(this);
+        initTestObjects();
+    }
+
+    @Test
+    public void testFindByUuid_NOT_FOUND_for_missing_uuid() throws Exception {
+        when(detectorRepo.findByUuid(anyString())).thenReturn(null);
+        mockMvc.perform(get("/api/v2/detectors/findByUuid").param("uuid", someUuid.toString())
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string("Invalid UUID: " + someUuid.toString()));
+    }
+
+    // TODO: "/findByCreatedBy" should return 404 NOT_FOUND for invalid user (instead of 400 BAD_REQUEST)
+    @Test
+    public void testFindByCreatedBy_BAD_REQUEST_for_invalid_user() throws Exception {
+        when(detectorRepo.findByCreatedBy(anyString())).thenReturn(null);
+        mockMvc.perform(get("/api/v2/detectors/findByCreatedBy").param("user", DUMMY_USER)
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Invalid user: " + DUMMY_USER));
+    }
+
+    private void initTestObjects() {
+        this.someUuid = UUID.randomUUID();
+    }
+
+}

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -101,11 +101,6 @@ public class DetectorControllerTest {
     }
 
     @Test
-    public void testFindByUuid_fail() throws Exception {
-        mockMvc.perform(get("/findByUuid").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
-    }
-
-    @Test
     public void testFindByCreatedBy() {
         when(detectorRepo.findByCreatedBy(anyString())).thenReturn(detectors);
         val actualDetectors = controllerUnderTest.findByCreatedBy("kashah");
@@ -125,7 +120,8 @@ public class DetectorControllerTest {
     }
 
     @Test
-    public void testFindByCreatedBy_fail() throws Exception {
+    public void testUrlsWithoutFullPath_fail() throws Exception {
+        mockMvc.perform(get("/findByUuid").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
         mockMvc.perform(get("/findByCreatedBy").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
     }
 


### PR DESCRIPTION
Make CustomExceptionHandler.handleRecordNotFound() public (was 'protected' previously which meant it wasn't handling RecordNotFoundException exceptions at all).

Added unit tests for CustomExceptionHandler