### PR TITLE
Changing log level to debug for testing purpose

### DIFF
--- a/kafka/src/main/resources/log4j.properties
+++ b/kafka/src/main/resources/log4j.properties
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 # Root logger option
-log4j.rootLogger=INFO, stdout
+# Changing the log level to DEBUG for testing purpose. We will change it back to INFO once we are done with the testing.
+# In future, we would like to do this with an environment variable.
+log4j.rootLogger=DEBUG, stdout
 
 # Direct log messages to stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
Changing the log level to DEBUG for testing purpose. We will change it back to INFO once done we are done with the testing.