### PR TITLE
Enhancement/multiple graphite calls

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-2020 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expedia.adaptivealerting.anomdetect.forecast.point;
+
+public interface SeasonalPointForecaster extends PointForecaster {
+
+    /**
+     * Number of observations per cycle.
+     */
+    int getCycleLength();
+
+    /**
+     * Number of seconds between two observations.
+     */
+    int getIntervalLength();
+
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.expedia.adaptivealerting.anomdetect.forecast.point;
 
 public interface SeasonalPointForecaster extends PointForecaster {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/SeasonalPointForecaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Expedia Group, Inc.
+ * Copyright 2018-2019 Expedia Group, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.expedia.adaptivealerting.anomdetect.forecast.point;
 
 public interface SeasonalPointForecaster extends PointForecaster {
-
     /**
      * Number of observations per cycle.
      */
@@ -26,5 +25,4 @@ public interface SeasonalPointForecaster extends PointForecaster {
      * Number of seconds between two observations.
      */
     int getIntervalLength();
-
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/algo/seasonalnaive/SeasonalNaivePointForecaster.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/forecast/point/algo/seasonalnaive/SeasonalNaivePointForecaster.java
@@ -16,7 +16,7 @@
 package com.expedia.adaptivealerting.anomdetect.forecast.point.algo.seasonalnaive;
 
 import com.expedia.adaptivealerting.anomdetect.forecast.point.PointForecast;
-import com.expedia.adaptivealerting.anomdetect.forecast.point.PointForecaster;
+import com.expedia.adaptivealerting.anomdetect.forecast.point.SeasonalPointForecaster;
 import com.expedia.metrics.MetricData;
 import lombok.Getter;
 import lombok.NonNull;
@@ -32,7 +32,7 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
  * https://otexts.com/fpp2/simple-methods.html#simple-methods.
  */
 @RequiredArgsConstructor
-public class SeasonalNaivePointForecaster implements PointForecaster {
+public class SeasonalNaivePointForecaster implements SeasonalPointForecaster {
 
     /**
      * Detector UUID.
@@ -78,6 +78,16 @@ public class SeasonalNaivePointForecaster implements PointForecaster {
         return getPreviousValueOrNull(oldValue);
     }
 
+    @Override
+    public int getCycleLength() {
+        return params.getCycleLength();
+    }
+
+    @Override
+    public int getIntervalLength() {
+        return params.getIntervalLength();
+    }
+
     private PointForecast getPreviousValueOrNull(double oldValue) {
         if (isWarmingUp()) {
             return new PointForecast(Double.NaN, true);
@@ -94,5 +104,4 @@ public class SeasonalNaivePointForecaster implements PointForecaster {
     private boolean bufferContainedMissingValue(double oldValue) {
         return this.params.getMissingValuePlaceholder().equals(oldValue);
     }
-
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
@@ -22,6 +22,6 @@ import java.util.List;
  */
 public interface DataSource {
 
-    List<DataSourceResult> getMetricData(int earliestTime, int binSizeInSecs, String metric);
+    List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int binSizeInSecs, String metric);
 
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
@@ -22,6 +22,6 @@ import java.util.List;
  */
 public interface DataSource {
 
-    List<DataSourceResult> getMetricData(int totalNoOfDays, int binSize, String metric);
+    List<DataSourceResult> getMetricData(int earliestTime, int binSizeInSecs, String metric);
 
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
@@ -22,6 +22,6 @@ import java.util.List;
  */
 public interface DataSource {
 
-    List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int binSizeInSecs, String metric);
+    List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int intervalLength, String target);
 
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/DataSource.java
@@ -22,6 +22,6 @@ import java.util.List;
  */
 public interface DataSource {
 
-    List<DataSourceResult> getMetricData(String from, Integer maxDataPoints, String metric);
+    List<DataSourceResult> getMetricData(int totalNoOfDays, int binSize, String metric);
 
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
@@ -38,7 +38,7 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 @RequiredArgsConstructor
 public class GraphiteClient {
 
-    public static final String FETCH_METRICS_PATH = "/render?from=-%ds&until=-%ds&format=json&maxDataPoints=%d&target=%s";
+    public static final String FETCH_METRICS_PATH = "/render?from=%d&until=%d&format=json&maxDataPoints=%d&target=%s";
 
     @NonNull
     private final String baseUri;
@@ -57,7 +57,7 @@ public class GraphiteClient {
      * @param target        metric name or tag with an optional graphite function
      * @return time series for the specified metric
      */
-    public List<GraphiteResult> getData(int from, int until, Integer maxDataPoints, String target) {
+    public List<GraphiteResult> getData(long from, long until, Integer maxDataPoints, String target) {
 
         notNull(from, "from can't be null");
         notNull(until, "until can't be null");

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
@@ -19,7 +19,6 @@ import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.http.client.fluent.Content;
 
@@ -37,7 +36,6 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
  * </p>
  */
 @RequiredArgsConstructor
-@Slf4j
 public class GraphiteClient {
 
     public static final String FETCH_METRICS_PATH = "/render?from=-%dd&until=-%dd&format=json&maxDataPoints=%d&target=%s";

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
@@ -19,6 +19,7 @@ import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.http.client.fluent.Content;
 
@@ -36,9 +37,10 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
  * </p>
  */
 @RequiredArgsConstructor
+@Slf4j
 public class GraphiteClient {
 
-    public static final String FETCH_METRICS_PATH = "/render?from=-%s&format=json&maxDataPoints=%d&target=%s";
+    public static final String FETCH_METRICS_PATH = "/render?from=-%dd&until=-%dd&format=json&maxDataPoints=%d&target=%s";
 
     @NonNull
     private final String baseUri;
@@ -57,12 +59,14 @@ public class GraphiteClient {
      * @param target        metric name or tag with an optional graphite function
      * @return time series for the specified metric
      */
-    public List<GraphiteResult> getData(String from, Integer maxDataPoints, String target) {
+    public List<GraphiteResult> getData(int from, int until, Integer maxDataPoints, String target) {
+
         notNull(from, "from can't be null");
+        notNull(until, "until can't be null");
         notNull(target, "target can't be null");
         notNull(maxDataPoints, "maxDataPoints can't be null");
 
-        val uri = String.format(baseUri + FETCH_METRICS_PATH, from, maxDataPoints, target);
+        val uri = String.format(baseUri + FETCH_METRICS_PATH, from, until, maxDataPoints, target);
         Content content;
         try {
             content = httpClient.get(uri);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClient.java
@@ -38,7 +38,7 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 @RequiredArgsConstructor
 public class GraphiteClient {
 
-    public static final String FETCH_METRICS_PATH = "/render?from=-%dd&until=-%dd&format=json&maxDataPoints=%d&target=%s";
+    public static final String FETCH_METRICS_PATH = "/render?from=-%ds&until=-%ds&format=json&maxDataPoints=%d&target=%s";
 
     @NonNull
     private final String baseUri;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -30,8 +30,7 @@ import java.util.List;
 public class GraphiteSource implements DataSource {
 
     public static final Double MISSING_VALUE = Double.NEGATIVE_INFINITY;
-    private static final int HOURS_PER_DAY = 24;
-    private static final int MINUTES_PER_HOUR = 60;
+    private static final int MINUTES_PER_DAY = 24 * 60;
 
     /**
      * Client to load metric data from graphite.
@@ -66,6 +65,6 @@ public class GraphiteSource implements DataSource {
     }
 
     private int getMaxDataPointsPerDay(int binSize) {
-        return (HOURS_PER_DAY * MINUTES_PER_HOUR) / binSize;
+        return MINUTES_PER_DAY / binSize;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -65,7 +65,7 @@ public class GraphiteSource implements DataSource {
         int from = earliestTimeInSecs - counter;
         int until = from - C.SECONDS_PER_DAY;
         log.debug("Fetching data from graphite for params:" +
-                "from={}, until={}, maxDataPoints={} and metric={} ", from, until, maxDataPoints, metric);
+                "from=-{}s, until=-{}s, maxDataPoints={} and metric={} ", from, until, maxDataPoints, metric);
         return graphiteClient.getData(from, until, maxDataPoints, metric);
     }
 

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -30,9 +30,8 @@ import java.util.List;
 public class GraphiteSource implements DataSource {
 
     public static final Double MISSING_VALUE = Double.NEGATIVE_INFINITY;
-    public static final int NO_OF_HOURS_DAY = 24;
-    public static final int NO_OF_MINS_IN_HOUR = 60;
-    public static final int BIN_SIZE = 5;
+    public static final int HOURS_PER_DAY = 24;
+    public static final int MINUTES_PER_HOUR = 60;
 
     /**
      * Client to load metric data from graphite.
@@ -67,6 +66,6 @@ public class GraphiteSource implements DataSource {
     }
 
     private int getMaxDataPointsPerDay(int binSize) {
-        return (NO_OF_HOURS_DAY * NO_OF_MINS_IN_HOUR) / binSize;
+        return (HOURS_PER_DAY * MINUTES_PER_HOUR) / binSize;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.time.Instant.ofEpochSecond;
+
 @RequiredArgsConstructor
 @Slf4j
 public class GraphiteSource implements DataSource {
@@ -38,10 +40,9 @@ public class GraphiteSource implements DataSource {
     private GraphiteClient graphiteClient;
 
     @Override
-    public List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int binSizeInSecs, String metric) {
-        int maxDataPoints = getMaxDataPointsPerDay(binSizeInSecs);
-        List<DataSourceResult> results = buildDataSourceResult(earliestTime, latestTime, maxDataPoints, metric);
-        return results;
+    public List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int intervalLength, String target) {
+        int maxDataPoints = getMaxDataPointsPerDay(intervalLength);
+        return buildDataSourceResult(earliestTime, latestTime, maxDataPoints, target);
     }
 
     private List<DataSourceResult> buildDataSourceResult(long earliestTime, long latestTime, int maxDataPoints, String metric) {
@@ -67,12 +68,12 @@ public class GraphiteSource implements DataSource {
 
     private List<GraphiteResult> getDataFromGraphite(long from, int maxDataPoints, String metric) {
         long until = from + TimeConstantsUtil.SECONDS_PER_DAY;
-        log.debug("Fetching data from graphite for params:" +
-                "from={}, until={}, maxDataPoints={} and metric={} ", from, until, maxDataPoints, metric);
+        log.debug("Fetching data from graphite for params: from={} ({}), until={} ({}), maxDataPoints={}, metric='{}'",
+                from, ofEpochSecond(from), until, ofEpochSecond(until), maxDataPoints, metric);
         return graphiteClient.getData(from, until, maxDataPoints, metric);
     }
 
-    private int getMaxDataPointsPerDay(int binSizeInSecs) {
-        return TimeConstantsUtil.SECONDS_PER_DAY / binSizeInSecs;
+    private int getMaxDataPointsPerDay(int intervalLength) {
+        return TimeConstantsUtil.SECONDS_PER_DAY / intervalLength;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -30,8 +30,8 @@ import java.util.List;
 public class GraphiteSource implements DataSource {
 
     public static final Double MISSING_VALUE = Double.NEGATIVE_INFINITY;
-    public static final int HOURS_PER_DAY = 24;
-    public static final int MINUTES_PER_HOUR = 60;
+    private static final int HOURS_PER_DAY = 24;
+    private static final int MINUTES_PER_HOUR = 60;
 
     /**
      * Client to load metric data from graphite.

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -37,20 +37,20 @@ import java.util.List;
 public class DataInitializer {
 
     public static final String BASE_URI = "graphite-base-uri";
-    public static final String EARLIEST_TIME = "graphite-earliest-time";
-    public static final String MAX_DATA_POINTS = "graphite-max-data-points";
+    public static final String BIN_SIZE = "graphite-bin-size-in-minutes";
     public static final String DATA_RETRIEVAL_TAG_KEY = "graphite-data-retrieval-key";
+    public static final String TOTAL_NO_OF_DAYS = "graphite-total-no-of-days";
 
     private String baseUri;
-    private String earliestTime;
-    private Integer maxDataPoints;
+    private int binSize;
     private String dataRetrievalTagKey;
+    private int totalNoOfDays;
 
     public DataInitializer(Config config) {
         this.baseUri = config.getString(BASE_URI);
-        this.earliestTime = config.getString(EARLIEST_TIME);
-        this.maxDataPoints = config.getInt(MAX_DATA_POINTS);
+        this.binSize = config.getInt(BIN_SIZE);
         this.dataRetrievalTagKey = config.getString(DATA_RETRIEVAL_TAG_KEY);
+        this.totalNoOfDays = config.getInt(TOTAL_NO_OF_DAYS);
     }
 
     public void initializeDetector(MappedMetricData mappedMetricData, Detector detector) {
@@ -78,7 +78,7 @@ public class DataInitializer {
         val target = MetricUtil.getDataRetrievalValueOrMetricKey(mappedMetricData, dataRetrievalTagKey);
         val client = makeClient(baseUri);
         val dataSource = makeSource(client);
-        return dataSource.getMetricData(earliestTime, maxDataPoints, target);
+        return dataSource.getMetricData(totalNoOfDays, binSize, target);
     }
 
     //TODO. Using one-line methods for object creation to support unit testing. We can replace this with factories later on.

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -82,7 +82,8 @@ public class DataInitializer {
             val earliestTime = cycleLength * intervalLength;
             return dataSource.getMetricData(earliestTime, intervalLength, target);
         } else {
-            throw new RuntimeException("Forecasting detector doesn't has a Seasonal point forecaster");
+            val message = "No seasonal point forecaster found for forecasting detector " + forecastingDetector.getUuid();
+            throw new RuntimeException(message);
         }
     }
 

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -79,8 +79,10 @@ public class DataInitializer {
             val seasonalPointForecaster = ((SeasonalPointForecaster) pointForecaster);
             val cycleLength = seasonalPointForecaster.getCycleLength();
             val intervalLength = seasonalPointForecaster.getIntervalLength();
-            val earliestTime = cycleLength * intervalLength;
-            return dataSource.getMetricData(earliestTime, intervalLength, target);
+            val fullWindow = cycleLength * intervalLength;
+            val latestTime = mappedMetricData.getMetricData().getTimestamp();
+            val earliestTime = latestTime - fullWindow;
+            return dataSource.getMetricData(earliestTime, latestTime, intervalLength, target);
         } else {
             val message = "No seasonal point forecaster found for forecasting detector " + forecastingDetector.getUuid();
             throw new RuntimeException(message);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class DataInitializer {
 
     public static final String BASE_URI = "graphite-base-uri";
-    public static final String BIN_SIZE = "graphite-bin-size-in-minutes";
+    public static final String BIN_SIZE = "graphite-bin-size-in-mins";
     public static final String DATA_RETRIEVAL_TAG_KEY = "graphite-data-retrieval-key";
     public static final String TOTAL_NO_OF_DAYS = "graphite-total-no-of-days";
 

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/C.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/C.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expedia.adaptivealerting.anomdetect.util;
 
-import lombok.Generated;
+import lombok.experimental.UtilityClass;
 
-@Generated
+@UtilityClass
 public class C {
     public static final int SECS_PER_MIN = 60;
     public static final int SECS_PER_HOUR = 60 * SECS_PER_MIN;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/C.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/C.java
@@ -1,0 +1,10 @@
+package com.expedia.adaptivealerting.anomdetect.util;
+
+import lombok.Generated;
+
+@Generated
+public class C {
+    public static final int SECS_PER_MIN = 60;
+    public static final int SECS_PER_HOUR = 60 * SECS_PER_MIN;
+    public static final int SECONDS_PER_DAY = 24 * SECS_PER_HOUR;
+}

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/TimeConstantsUtil.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/TimeConstantsUtil.java
@@ -18,8 +18,8 @@ package com.expedia.adaptivealerting.anomdetect.util;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public class C {
-    public static final int SECS_PER_MIN = 60;
-    public static final int SECS_PER_HOUR = 60 * SECS_PER_MIN;
-    public static final int SECONDS_PER_DAY = 24 * SECS_PER_HOUR;
+public class TimeConstantsUtil {
+    public static final int SECONDS_PER_MIN = 60;
+    public static final int SECONDS_PER_HOUR = 60 * SECONDS_PER_MIN;
+    public static final int SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.when;
 @Slf4j
 public class GraphiteClientTest {
     private static final String BASE_URI = "http://graphite";
-    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, "1d", 288, "metricName");
-    private static final String METRIC_URI_CANT_GET = uri(FETCH_METRICS_PATH, "1d", 288, "metricNameCantGet");
-    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, "1d", 288, "metricNameCantRead");
+    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, 2, 1,288, "metricName");
+    private static final String METRIC_URI_CANT_GET = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricNameCantGet");
+    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, 2,1, 288, "metricNameCantRead");
 
     private GraphiteClient clientUnderTest;
 
@@ -38,7 +38,8 @@ public class GraphiteClientTest {
     private byte[] docsBytes = "docsBytes".getBytes();
     private byte[] docBytes_cantRead = "docBytes_cantRead".getBytes();
     private GraphiteResult[] docs = {};
-    private String from = "1d";
+    private int from = 2;
+    private int until = 1;
     private Integer maxDataPoints = 288;
 
     @Before
@@ -50,17 +51,17 @@ public class GraphiteClientTest {
 
     @Test
     public void testGetMetricData() {
-        clientUnderTest.getData(from, maxDataPoints, "metricName");
+        clientUnderTest.getData(from, until, maxDataPoints, "metricName");
     }
 
     @Test(expected = RuntimeException.class)
     public void testGetMetricData_cant_get() {
-        clientUnderTest.getData(from, maxDataPoints, "metricNameCantGet");
+        clientUnderTest.getData(from, until, maxDataPoints, "metricNameCantGet");
     }
 
     @Test(expected = RuntimeException.class)
     public void testGetMetricData_cant_read() {
-        clientUnderTest.getData(from, maxDataPoints, "metricNameCantRead");
+        clientUnderTest.getData(from, until, maxDataPoints, "metricNameCantRead");
     }
 
     private void initMetricData() throws IOException {
@@ -75,8 +76,8 @@ public class GraphiteClientTest {
         when(objectMapper.readValue(docBytes_cantRead, GraphiteResult[].class)).thenThrow(new IOException());
     }
 
-    private static String uri(String path, Object param, Object param1, Object param2) {
-        return String.format(BASE_URI + path, param, param1, param2);
+    private static String uri(String path, Object param, Object param1, Object param2, Object param3) {
+        return String.format(BASE_URI + path, param, param1, param2, param3);
     }
 
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.when;
 @Slf4j
 public class GraphiteClientTest {
     private static final String BASE_URI = "http://graphite";
-    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricName");
-    private static final String METRIC_URI_CANT_GET = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricNameCantGet");
-    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricNameCantRead");
+    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, 1580815495, 1580901895, 288, "metricName");
+    private static final String METRIC_URI_CANT_GET = uri(FETCH_METRICS_PATH, 1580815495, 1580901895, 288, "metricNameCantGet");
+    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, 1580815495, 1580901895, 288, "metricNameCantRead");
 
     private GraphiteClient clientUnderTest;
 
@@ -38,8 +38,8 @@ public class GraphiteClientTest {
     private byte[] docsBytes = "docsBytes".getBytes();
     private byte[] docBytes_cantRead = "docBytes_cantRead".getBytes();
     private GraphiteResult[] docs = {};
-    private int from = 2;
-    private int until = 1;
+    private long from = 1580815495;
+    private long until = 1580901895;
     private Integer maxDataPoints = 288;
 
     @Before

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.when;
 @Slf4j
 public class GraphiteClientTest {
     private static final String BASE_URI = "http://graphite";
-    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, 2, 1,288, "metricName");
+    private static final String METRIC_URI = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricName");
     private static final String METRIC_URI_CANT_GET = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricNameCantGet");
-    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, 2,1, 288, "metricNameCantRead");
+    private static final String METRIC_URI_CANT_READ = uri(FETCH_METRICS_PATH, 2, 1, 288, "metricNameCantRead");
 
     private GraphiteClient clientUnderTest;
 

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -64,10 +64,8 @@ public class GraphiteSourceTest {
     }
 
     private void initDependencies() {
-        when(graphiteClient.getData(3, 2, 288, "metric_name")).thenReturn(graphiteResults);
         when(graphiteClient.getData(2, 1, 288, "metric_name")).thenReturn(graphiteResults);
         when(graphiteClient.getData(1, 0, 288, "metric_name")).thenReturn(graphiteResults);
-
         when(graphiteClient.getData(1, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
         when(graphiteClient.getData(1, 0, 288, "null_value")).thenReturn(graphiteResults_null);
     }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -21,7 +21,6 @@ public class GraphiteSourceTest {
     private GraphiteSource sourceUnderTest;
     private List<GraphiteResult> graphiteResults = new ArrayList<>();
     private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
-    private int totalNoOfDays = 1;
     private int binSize = 5;
 
     @Before
@@ -37,20 +36,22 @@ public class GraphiteSourceTest {
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
         dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
 
-        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "metric_name");
+        val actual = sourceUnderTest.getMetricData(2, binSize, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "null_metric");
+        val actual = sourceUnderTest.getMetricData(1, binSize, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "null_value");
+        val actual = sourceUnderTest.getMetricData(1, binSize, "null_value");
         val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, 1578307488);
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);
@@ -63,7 +64,10 @@ public class GraphiteSourceTest {
     }
 
     private void initDependencies() {
+        when(graphiteClient.getData(3, 2, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(2, 1, 288, "metric_name")).thenReturn(graphiteResults);
         when(graphiteClient.getData(1, 0, 288, "metric_name")).thenReturn(graphiteResults);
+
         when(graphiteClient.getData(1, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
         when(graphiteClient.getData(1, 0, 288, "null_value")).thenReturn(graphiteResults_null);
     }
@@ -93,4 +97,5 @@ public class GraphiteSourceTest {
         dataSourceResult.setEpochSecond(epochSecs);
         return dataSourceResult;
     }
+
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -1,6 +1,7 @@
 package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
+import com.expedia.adaptivealerting.anomdetect.util.C;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class GraphiteSourceTest {
     private GraphiteSource sourceUnderTest;
     private List<GraphiteResult> graphiteResults = new ArrayList<>();
     private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
-    private int binSize = 5;
+    private int binSizeInSecs = 5 * C.SECS_PER_MIN;
 
     @Before
     public void setUp() {
@@ -38,20 +39,30 @@ public class GraphiteSourceTest {
         dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
         dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
         dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
 
-        val actual = sourceUnderTest.getMetricData(2, binSize, "metric_name");
+        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY * 7, binSizeInSecs, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(1, binSize, "null_metric");
+        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY, binSizeInSecs, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(1, binSize, "null_value");
+        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY, binSizeInSecs, "null_value");
         val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, 1578307488);
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);
@@ -64,10 +75,15 @@ public class GraphiteSourceTest {
     }
 
     private void initDependencies() {
-        when(graphiteClient.getData(2, 1, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(1, 0, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(1, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
-        when(graphiteClient.getData(1, 0, 288, "null_value")).thenReturn(graphiteResults_null);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 7, C.SECONDS_PER_DAY * 6, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 6, C.SECONDS_PER_DAY * 5, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 5, C.SECONDS_PER_DAY * 4, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 4, C.SECONDS_PER_DAY * 3, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 3, C.SECONDS_PER_DAY * 2, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY * 2, C.SECONDS_PER_DAY, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
+        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "null_value")).thenReturn(graphiteResults_null);
     }
 
     private GraphiteResult buildGraphiteResult() {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -22,7 +22,7 @@ public class GraphiteSourceTest {
     private GraphiteSource sourceUnderTest;
     private List<GraphiteResult> graphiteResults = new ArrayList<>();
     private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
-    private int binSizeInSecs = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
+    private int intervalLength = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
 
     @Before
     public void setUp() {
@@ -35,19 +35,19 @@ public class GraphiteSourceTest {
     @Test
     public void testGetMetricData() {
         val dataSourceResults = buildDataSourceResults();
-        val actual = sourceUnderTest.getMetricData(1580297095, 1580901895, binSizeInSecs, "metric_name");
+        val actual = sourceUnderTest.getMetricData(1580297095, 1580901895, intervalLength, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, binSizeInSecs, "null_metric");
+        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, intervalLength, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, binSizeInSecs, "null_value");
+        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, intervalLength, "null_value");
         val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, 1578307488);
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.mockito.Mockito.when;
 
 public class GraphiteSourceTest {
@@ -22,8 +21,8 @@ public class GraphiteSourceTest {
     private GraphiteSource sourceUnderTest;
     private List<GraphiteResult> graphiteResults = new ArrayList<>();
     private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
-    private String from = "1d";
-    private Integer maxDataPoints = 288;
+    private int totalNoOfDays = 1;
+    private int binSize = 5;
 
     @Before
     public void setUp() {
@@ -39,19 +38,19 @@ public class GraphiteSourceTest {
         dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
         dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
 
-        val actual = sourceUnderTest.getMetricData(from, maxDataPoints, "metric_name");
+        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(from, maxDataPoints, "null_metric");
+        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(from, maxDataPoints, "null_value");
+        val actual = sourceUnderTest.getMetricData(totalNoOfDays, binSize, "null_value");
         val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, 1578307488);
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);
@@ -64,9 +63,9 @@ public class GraphiteSourceTest {
     }
 
     private void initDependencies() {
-        when(graphiteClient.getData(from, maxDataPoints, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(from, maxDataPoints, "null_metric")).thenReturn(new ArrayList<>());
-        when(graphiteClient.getData(from, maxDataPoints, "null_value")).thenReturn(graphiteResults_null);
+        when(graphiteClient.getData(1, 0, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
+        when(graphiteClient.getData(1, 0, 288, "null_value")).thenReturn(graphiteResults_null);
     }
 
     private GraphiteResult buildGraphiteResult() {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -34,8 +34,15 @@ public class GraphiteSourceTest {
 
     @Test
     public void testGetMetricData() {
-        val dataSourceResults = buildDataSourceResults();
+        val dataSourceResults = buildDataSourceResults(7);
         val actual = sourceUnderTest.getMetricData(1580297095, 1580901895, intervalLength, "metric_name");
+        assertEquals(dataSourceResults, actual);
+    }
+
+    @Test
+    public void testGetMetricData_time_window_less_than_day() {
+        val dataSourceResults = buildDataSourceResults(1);
+        val actual = sourceUnderTest.getMetricData(1580297095, 1580340295, intervalLength, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
@@ -67,6 +74,9 @@ public class GraphiteSourceTest {
         when(graphiteClient.getData(1580642695, 1580729095, 288, "metric_name")).thenReturn(graphiteResults);
         when(graphiteClient.getData(1580729095, 1580815495, 288, "metric_name")).thenReturn(graphiteResults);
         when(graphiteClient.getData(1580815495, 1580901895, 288, "metric_name")).thenReturn(graphiteResults);
+
+        when(graphiteClient.getData(1580297095, 1580383495, 288, "metric_name")).thenReturn(graphiteResults);
+
         when(graphiteClient.getData(1580815495, 1580901895, 288, "null_metric")).thenReturn(new ArrayList<>());
         when(graphiteClient.getData(1580815495, 1580901895, 288, "null_value")).thenReturn(graphiteResults_null);
     }
@@ -90,10 +100,10 @@ public class GraphiteSourceTest {
         return graphiteResult;
     }
 
-    private List<DataSourceResult> buildDataSourceResults() {
+    private List<DataSourceResult> buildDataSourceResults(int noOfResults) {
 
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
-        for (int i = 0; i < 7; i++) {
+        for (int i = 0; i < noOfResults; i++) {
             dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
             dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
         }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -1,7 +1,7 @@
 package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
-import com.expedia.adaptivealerting.anomdetect.util.C;
+import com.expedia.adaptivealerting.anomdetect.util.TimeConstantsUtil;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +22,7 @@ public class GraphiteSourceTest {
     private GraphiteSource sourceUnderTest;
     private List<GraphiteResult> graphiteResults = new ArrayList<>();
     private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
-    private int binSizeInSecs = 5 * C.SECS_PER_MIN;
+    private int binSizeInSecs = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
 
     @Before
     public void setUp() {
@@ -34,35 +34,20 @@ public class GraphiteSourceTest {
 
     @Test
     public void testGetMetricData() {
-        List<DataSourceResult> dataSourceResults = new ArrayList<>();
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-        dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-        dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
-
-        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY * 7, binSizeInSecs, "metric_name");
+        val dataSourceResults = buildDataSourceResults();
+        val actual = sourceUnderTest.getMetricData(1580297095, 1580901895, binSizeInSecs, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY, binSizeInSecs, "null_metric");
+        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, binSizeInSecs, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(C.SECONDS_PER_DAY, binSizeInSecs, "null_value");
+        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, binSizeInSecs, "null_value");
         val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, 1578307488);
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);
@@ -75,15 +60,15 @@ public class GraphiteSourceTest {
     }
 
     private void initDependencies() {
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 7, C.SECONDS_PER_DAY * 6, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 6, C.SECONDS_PER_DAY * 5, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 5, C.SECONDS_PER_DAY * 4, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 4, C.SECONDS_PER_DAY * 3, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 3, C.SECONDS_PER_DAY * 2, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY * 2, C.SECONDS_PER_DAY, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "metric_name")).thenReturn(graphiteResults);
-        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "null_metric")).thenReturn(new ArrayList<>());
-        when(graphiteClient.getData(C.SECONDS_PER_DAY, 0, 288, "null_value")).thenReturn(graphiteResults_null);
+        when(graphiteClient.getData(1580297095, 1580383495, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580383495, 1580469895, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580469895, 1580556295, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580556295, 1580642695, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580642695, 1580729095, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580729095, 1580815495, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580815495, 1580901895, 288, "metric_name")).thenReturn(graphiteResults);
+        when(graphiteClient.getData(1580815495, 1580901895, 288, "null_metric")).thenReturn(new ArrayList<>());
+        when(graphiteClient.getData(1580815495, 1580901895, 288, "null_value")).thenReturn(graphiteResults_null);
     }
 
     private GraphiteResult buildGraphiteResult() {
@@ -103,6 +88,16 @@ public class GraphiteSourceTest {
         };
         graphiteResult.setDatapoints(dataPoints);
         return graphiteResult;
+    }
+
+    private List<DataSourceResult> buildDataSourceResults() {
+
+        List<DataSourceResult> dataSourceResults = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
+            dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        }
+        return dataSourceResults;
     }
 
     private DataSourceResult buildDataSourceResult(Double value, long epochSecs) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -68,8 +68,6 @@ public class DataInitializerTest {
 
     private void initConfig() {
         when(config.getString(DataInitializer.BASE_URI)).thenReturn("http://graphite");
-        when(config.getInt(DataInitializer.BIN_SIZE)).thenReturn(5);
-        when(config.getInt(DataInitializer.TOTAL_NO_OF_DAYS)).thenReturn(7);
     }
 
     public void initTestObjects() {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -98,7 +98,7 @@ public class DataInitializerTest {
     }
 
     private Detector buildDetector() {
-        val seasonalNaivePointForecaster = new SeasonalNaivePointForecaster(new SeasonalNaivePointForecasterParams().setCycleLength(22).setIntervalLength(11));
+        val seasonalNaivePointForecaster = new SeasonalNaivePointForecaster(new SeasonalNaivePointForecasterParams().setCycleLength(2016).setIntervalLength(300));
         val multiplicativeIntervalForecaster = new MultiplicativeIntervalForecaster(new MultiplicativeIntervalForecasterParams().setStrongMultiplier(3.0).setWeakMultiplier(1.0));
         return new ForecastingDetector(UUID.randomUUID(), seasonalNaivePointForecaster, multiplicativeIntervalForecaster, AnomalyType.TWO_TAILED, true, "seasonalnaive");
     }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -68,8 +68,8 @@ public class DataInitializerTest {
 
     private void initConfig() {
         when(config.getString(DataInitializer.BASE_URI)).thenReturn("http://graphite");
-        when(config.getString(DataInitializer.EARLIEST_TIME)).thenReturn("7d");
-        when(config.getInt(DataInitializer.MAX_DATA_POINTS)).thenReturn(2016);
+        when(config.getInt(DataInitializer.BIN_SIZE)).thenReturn(5);
+        when(config.getInt(DataInitializer.TOTAL_NO_OF_DAYS)).thenReturn(7);
     }
 
     public void initTestObjects() {
@@ -96,7 +96,7 @@ public class DataInitializerTest {
     private void initDependencies() {
         when(initializerUnderTest.makeClient(anyString())).thenReturn(graphiteClient);
         when(initializerUnderTest.makeSource(graphiteClient)).thenReturn(dataSource);
-        when(dataSource.getMetricData(anyString(), anyInt(), anyString())).thenReturn(dataSourceResults);
+        when(dataSource.getMetricData(anyInt(), anyInt(), anyString())).thenReturn(dataSourceResults);
     }
 
     private DataSourceResult buildDataSourceResult(Double value, long epochSecs) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.spy;
@@ -105,7 +106,7 @@ public class DataInitializerTest {
     private void initDependencies() {
         when(initializerUnderTest.makeClient(anyString())).thenReturn(graphiteClient);
         when(initializerUnderTest.makeSource(graphiteClient)).thenReturn(dataSource);
-        when(dataSource.getMetricData(anyInt(), anyInt(), anyString())).thenReturn(dataSourceResults);
+        when(dataSource.getMetricData(anyLong(), anyLong(), anyInt(), anyString())).thenReturn(dataSourceResults);
     }
 
     private DataSourceResult buildDataSourceResult(Double value, long epochSecs) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -6,6 +6,8 @@ import com.expedia.adaptivealerting.anomdetect.detect.MappedMetricData;
 import com.expedia.adaptivealerting.anomdetect.detect.outlier.algo.forecasting.ForecastingDetector;
 import com.expedia.adaptivealerting.anomdetect.forecast.interval.algo.multiplicative.MultiplicativeIntervalForecaster;
 import com.expedia.adaptivealerting.anomdetect.forecast.interval.algo.multiplicative.MultiplicativeIntervalForecasterParams;
+import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.pewma.PewmaPointForecaster;
+import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.pewma.PewmaPointForecasterParams;
 import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.seasonalnaive.SeasonalNaivePointForecaster;
 import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.seasonalnaive.SeasonalNaivePointForecasterParams;
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSource;
@@ -62,6 +64,15 @@ public class DataInitializerTest {
 
     @Test
     public void testInitializeDetector() {
+        initializerUnderTest.initializeDetector(mappedMetricData, detector);
+        verify(initializerUnderTest, atMost(1)).initializeDetector(any(MappedMetricData.class), any(Detector.class));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testInitializeDetector_illegal_point_forecaster() {
+        val pwmaPointForecaster = new PewmaPointForecaster(new PewmaPointForecasterParams().setAlpha(1.0).setBeta(2.0));
+        val multiplicativeIntervalForecaster = new MultiplicativeIntervalForecaster(new MultiplicativeIntervalForecasterParams().setStrongMultiplier(3.0).setWeakMultiplier(1.0));
+        val detector = new ForecastingDetector(UUID.randomUUID(), pwmaPointForecaster, multiplicativeIntervalForecaster, AnomalyType.TWO_TAILED, true, "seasonalnaive");
         initializerUnderTest.initializeDetector(mappedMetricData, detector);
         verify(initializerUnderTest, atMost(1)).initializeDetector(any(MappedMetricData.class), any(Detector.class));
     }

--- a/deployment/terraform/ad-manager/main.tf
+++ b/deployment/terraform/ad-manager/main.tf
@@ -23,9 +23,7 @@ data "template_file" "config_data" {
     anomaly_producer_value_serializer = "${var.anomaly_producer_value_serializer}"
     modelservice_base_uri = "${var.modelservice_base_uri}"
     graphite_base_uri = "${var.graphite_base_uri}"
-    graphite_bin_size_in_mins = "${var.graphite_bin_size_in_mins}
     graphite_data_retrieval_key = "${var.graphite_data_retrieval_key}"
-    graphite_total_no_of_days = "${var.graphite_total_no_of_days}
     detector_refresh_period = "${var.detector_refresh_period}"
   }
 }

--- a/deployment/terraform/ad-manager/main.tf
+++ b/deployment/terraform/ad-manager/main.tf
@@ -23,9 +23,9 @@ data "template_file" "config_data" {
     anomaly_producer_value_serializer = "${var.anomaly_producer_value_serializer}"
     modelservice_base_uri = "${var.modelservice_base_uri}"
     graphite_base_uri = "${var.graphite_base_uri}"
-    graphite_earliest_time ="${var.graphite_earliest_time}"
-    graphite_max_data_points = "${var.graphite_max_data_points}"
+    graphite_bin_size_in_mins = "${var.graphite_bin_size_in_mins}
     graphite_data_retrieval_key = "${var.graphite_data_retrieval_key}"
+    graphite_total_no_of_days = "${var.graphite_total_no_of_days}
     detector_refresh_period = "${var.detector_refresh_period}"
   }
 }

--- a/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
+++ b/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
@@ -18,7 +18,7 @@ ad-manager {
 
  # Graphite data source config
   graphite-base-uri = "${graphite_base_uri}"
-  graphite-bin-size-in-minutes = "${graphite_bin_size_in_mins}"
+  graphite-bin-size-in-mins = "${graphite_bin_size_in_mins}"
   graphite-data-retrieval-key = "${graphite_data_retrieval_key}"
   graphite-total-no-of-days = "${graphite_total_no_of_days}"
 

--- a/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
+++ b/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
@@ -18,9 +18,9 @@ ad-manager {
 
  # Graphite data source config
   graphite-base-uri = "${graphite_base_uri}"
-  graphite-earliest-time ="${graphite_earliest_time}"
-  graphite-max-data-points = "${graphite_max_data_points}"
+  graphite-bin-size-in-minutes = "${graphite_bin_size_in_mins}"
   graphite-data-retrieval-key = "${graphite_data_retrieval_key}"
+  graphite-total-no-of-days = "${graphite_total_no_of_days}"
 
   # Detector refresh period in minutes
   detector-refresh-period = ${detector_refresh_period}

--- a/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
+++ b/deployment/terraform/ad-manager/templates/ad-manager_conf.tpl
@@ -18,9 +18,7 @@ ad-manager {
 
  # Graphite data source config
   graphite-base-uri = "${graphite_base_uri}"
-  graphite-bin-size-in-mins = "${graphite_bin_size_in_mins}"
   graphite-data-retrieval-key = "${graphite_data_retrieval_key}"
-  graphite-total-no-of-days = "${graphite_total_no_of_days}"
 
   # Detector refresh period in minutes
   detector-refresh-period = ${detector_refresh_period}

--- a/deployment/terraform/ad-manager/variables.tf
+++ b/deployment/terraform/ad-manager/variables.tf
@@ -40,9 +40,9 @@ variable "anomaly_producer_key_serializer" {}
 variable "anomaly_producer_value_serializer" {}
 variable "modelservice_base_uri" {}
 variable "graphite_base_uri" {}
-variable "graphite_earliest_time" {}
-variable "graphite_max_data_points" {}
+variable "graphite_bin_size_in_mins" {}
 variable "graphite_data_retrieval_key" {}
+variable "graphite_total_no_of_days" {}
 variable "detector_refresh_period" {
   default = 5
 }

--- a/deployment/terraform/ad-manager/variables.tf
+++ b/deployment/terraform/ad-manager/variables.tf
@@ -40,9 +40,7 @@ variable "anomaly_producer_key_serializer" {}
 variable "anomaly_producer_value_serializer" {}
 variable "modelservice_base_uri" {}
 variable "graphite_base_uri" {}
-variable "graphite_bin_size_in_mins" {}
 variable "graphite_data_retrieval_key" {}
-variable "graphite_total_no_of_days" {}
 variable "detector_refresh_period" {
   default = 5
 }

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -80,9 +80,7 @@ module "ad-manager" {
   anomaly_producer_value_serializer = "${var.ad-manager["anomaly_producer_value_serializer"]}"
   modelservice_base_uri = "${var.ad-manager["modelservice_base_uri"]}"
   graphite_base_uri = "${var.ad-manager["graphite_base_uri"]}"
-  graphite_bin_size_in_mins = "${var.ad-manager["graphite_bin_size_in_mins"]}"
   graphite_data_retrieval_key = "${var.ad-manager["graphite_data_retrieval_key"]}"
-  graphite_total_no_of_days = "${var.ad-manager["graphite_total_no_of_days"]}"
   detector_refresh_period = "${var.ad-manager["detector_refresh_period"]}"
 }
 

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -80,9 +80,9 @@ module "ad-manager" {
   anomaly_producer_value_serializer = "${var.ad-manager["anomaly_producer_value_serializer"]}"
   modelservice_base_uri = "${var.ad-manager["modelservice_base_uri"]}"
   graphite_base_uri = "${var.ad-manager["graphite_base_uri"]}"
-  graphite_earliest_time = "${var.ad-manager["graphite_earliest_time"]}"
-  graphite_max_data_points = "${var.ad-manager["graphite_max_data_points"]}"
+  graphite_bin_size_in_mins = "${var.ad-manager["graphite_bin_size_in_mins"]}"
   graphite_data_retrieval_key = "${var.ad-manager["graphite_data_retrieval_key"]}"
+  graphite_total_no_of_days = "${var.ad-manager["graphite_total_no_of_days"]}"
   detector_refresh_period = "${var.ad-manager["detector_refresh_period"]}"
 }
 

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -31,7 +31,7 @@ ad-manager {
   detector-refresh-period = 5
   model-service-base-uri = "http://modelservice:8008"
   graphite-base-uri = "http://graphite"
-  graphite-bin-size-in-minutes = 5
+  graphite-bin-size-in-mins = 5
   graphite-data-retrieval-key = "data-retrieval-key"
   graphite-total-no-of-days = 7
 }

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -31,9 +31,9 @@ ad-manager {
   detector-refresh-period = 5
   model-service-base-uri = "http://modelservice:8008"
   graphite-base-uri = "http://graphite"
-  graphite-earliest-time = "7d"
-  graphite-max-data-points = 2016
+  graphite-bin-size-in-minutes = 5
   graphite-data-retrieval-key = "data-retrieval-key"
+  graphite-total-no-of-days = 7
 }
 
 a2a-mapper {

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -31,9 +31,7 @@ ad-manager {
   detector-refresh-period = 5
   model-service-base-uri = "http://modelservice:8008"
   graphite-base-uri = "http://graphite"
-  graphite-bin-size-in-mins = 5
   graphite-data-retrieval-key = "data-retrieval-key"
-  graphite-total-no-of-days = 7
 }
 
 a2a-mapper {

--- a/kafka/src/test/resources/detector-manager.conf
+++ b/kafka/src/test/resources/detector-manager.conf
@@ -18,7 +18,7 @@ anomaly-producer {
 model-service-base-uri = "https://example.com/"
 
 graphite-base-uri = "http://graphite"
-graphite-bin-size-in-minutes = 5
+graphite-bin-size-in-mins = 5
 graphite-data-retrieval-key = "data-retrieval-key"
 graphite-total-no-of-days = 7
 

--- a/kafka/src/test/resources/detector-manager.conf
+++ b/kafka/src/test/resources/detector-manager.conf
@@ -18,9 +18,7 @@ anomaly-producer {
 model-service-base-uri = "https://example.com/"
 
 graphite-base-uri = "http://graphite"
-graphite-bin-size-in-mins = 5
 graphite-data-retrieval-key = "data-retrieval-key"
-graphite-total-no-of-days = 7
 
 # Detector refresh period in minutes
 detector-refresh-period = 5

--- a/kafka/src/test/resources/detector-manager.conf
+++ b/kafka/src/test/resources/detector-manager.conf
@@ -18,9 +18,9 @@ anomaly-producer {
 model-service-base-uri = "https://example.com/"
 
 graphite-base-uri = "http://graphite"
-graphite-earliest-time = "7d"
-graphite-max-data-points = 2016
+graphite-bin-size-in-minutes = 5
 graphite-data-retrieval-key = "data-retrieval-key"
+graphite-total-no-of-days = 7
 
 # Detector refresh period in minutes
 detector-refresh-period = 5


### PR DESCRIPTION
Make multiple Graphite calls (1 day) to fetch 7 days of data and stitch it together as fetching whole 7 days of data in a single call is throwing a timeout error. With this change, `total no of days` and `bin size` are now user-defined params.

```2020-02-05 12:01:59 INFO  DataInitializer:65 () - Initializing detector data
2020-02-05 12:01:59 INFO  DataInitializer:67 () - Fetched total of 2 historical data points for buffer
2020-02-05 12:01:59 DEBUG SeasonalBuffer:112 () - First data point received for Seasonal Buffer. Buffer has cycleLength=22, interval=11, and starts at timestamp 1578307488 (2020-01-06T10:44:48Z). First metric details: MetricData{metricDefinition=MetricDefinition{key='metric-definition', tags=TagCollection{kv={}, v=[]}, meta=TagCollection{kv={}, v=[]}}, value=1.0, timestamp=1578307488}
2020-02-05 12:01:59 DEBUG SeasonalBuffer:149 () - Updating buffer index 0 with value 1.0
2020-02-05 12:01:59 DEBUG SeasonalBuffer:160 () - Current metric timestamp 1578307489 (2020-01-06T10:44:49Z) includes -1 skipped data points since last timestamp 1578307488 (2020-01-06T10:44:48Z)
2020-02-05 12:01:59 DEBUG SeasonalBuffer:149 () - Updating buffer index 1 with value 3.0
2020-02-05 12:01:59 INFO  DataInitializer:70 () - Replayed 2 historical data points for ForecastingDetector```


Use ABSOLUTE time instead of RELATIVE TIME to query graphite.
Sample graphite call log:

2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580297095, until=1580383495, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580383495, until=1580469895, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580469895, until=1580556295, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580556295, until=1580642695, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580642695, until=1580729095, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580729095, until=1580815495, maxDataPoints=288 and metric=metric_name 
2020-02-06 13:24:46 DEBUG GraphiteSource:70 () - Fetching data from graphite for params:from=1580815495, until=1580901895, maxDataPoints=288 and metric=metric_name 