### PR TITLE
Added detector uuid in data init logs

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -58,12 +58,13 @@ public class DataInitializer {
     }
 
     private void initializeForecastingDetector(MappedMetricData mappedMetricData, ForecastingDetector forecastingDetector) {
-        log.info("Initializing detector data");
+        val detectorUUID = forecastingDetector.getUuid();
+        log.info("Initializing detector data for detector UUID {}", detectorUUID);
         val data = getHistoricalData(mappedMetricData, forecastingDetector);
-        log.info("Fetched total of {} historical data points for buffer", data.size());
+        log.info("Fetched total of {} historical data points to populate buffer for detector UUID {}", data.size(), detectorUUID);
         val metricDefinition = mappedMetricData.getMetricData().getMetricDefinition();
         populateForecastingDetectorWithHistoricalData(forecastingDetector, data, metricDefinition);
-        log.info("Replayed {} historical data points for {}", data.size(), forecastingDetector.getClass().getSimpleName());
+        log.info("Replayed {} historical data points for detector UUID {}", data.size(), detectorUUID);
     }
 
     private boolean isSeasonalNaiveDetector(Detector detector) {


### PR DESCRIPTION
Added detector UUID in data init logs

Logs sample:

``` 2020-02-07 15:01:07 INFO  DataInitializer:62 () - Initializing detector data for detector UUID 14138db8-a8ca-43a0-9542-56b12f5304b3
2020-02-07 15:01:07 INFO  DataInitializer:64 () - Fetched total of 2 historical data points to populate buffer for detector UUID 14138db8-a8ca-43a0-9542-56b12f5304b3
2020-02-07 15:01:07 DEBUG SeasonalBuffer:112 () - First data point received for Seasonal Buffer. Buffer has cycleLength=2016, interval=300, and starts at timestamp 1578307488 (2020-01-06T10:44:48Z). First metric details: MetricData{metricDefinition=MetricDefinition{key='metric-definition', tags=TagCollection{kv={}, v=[]}, meta=TagCollection{kv={}, v=[]}}, value=1.0, timestamp=1578307488}
2020-02-07 15:01:07 DEBUG SeasonalBuffer:149 () - Updating buffer index 0 with value 1.0
2020-02-07 15:01:07 DEBUG SeasonalBuffer:160 () - Current metric timestamp 1578307489 (2020-01-06T10:44:49Z) includes -1 skipped data points since last timestamp 1578307488 (2020-01-06T10:44:48Z)
2020-02-07 15:01:07 DEBUG SeasonalBuffer:149 () - Updating buffer index 1 with value 3.0
2020-02-07 15:01:07 INFO  DataInitializer:67 () - Replayed 2 historical data points for detector UUID 14138db8-a8ca-43a0-9542-56b12f5304b3
