### PR TITLE
Snap time to interval length while querying graphite and discard last…

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -38,8 +38,6 @@ import java.util.List;
 public class DataInitializer {
 
     public static final String BASE_URI = "graphite-base-uri";
-    public static final String EARLIEST_TIME = "graphite-earliest-time";
-    public static final String MAX_DATA_POINTS = "graphite-max-data-points";
     public static final String DATA_RETRIEVAL_TAG_KEY = "graphite-data-retrieval-key";
     public static final String THROTTLE_GATE_LIKELIHOOD = "throttle-gate-likelihood";
 
@@ -89,27 +87,14 @@ public class DataInitializer {
             val cycleLength = seasonalPointForecaster.getCycleLength();
             val intervalLength = seasonalPointForecaster.getIntervalLength();
             val fullWindow = cycleLength * intervalLength;
-            val latestTime = calculateLatestTime(mappedMetricData, intervalLength);
-            val earliestTime = calculateEarliestTime(fullWindow, latestTime);
+            val latestTime = mappedMetricData.getMetricData().getTimestamp();
+            val earliestTime = latestTime - fullWindow;
             return dataSource.getMetricData(earliestTime, latestTime, intervalLength, target);
         } else {
             // TODO: Write a test for this:
             val message = "No seasonal point forecaster found for forecasting detector " + forecastingDetector.getUuid();
             throw new RuntimeException(message);
         }
-    }
-
-    // TODO: Write a test for this
-    private long calculateEarliestTime(int fullWindow, long latestTime) {
-        return latestTime - fullWindow;
-    }
-
-    // TODO: Write a test for this
-    private long calculateLatestTime(MappedMetricData mappedMetricData, int intervalLength) {
-        long currentMetricTimestamp = mappedMetricData.getMetricData().getTimestamp();
-        long startOfCurrentBin = (currentMetricTimestamp / intervalLength) * intervalLength;
-        // We subtract 2 seconds to ensure current bin is not included in Graphite data retrieval. Why 2 seconds? 1 second does not reliably do this.
-        return startOfCurrentBin - 2;
     }
 
     private void populateForecastingDetectorWithHistoricalData(ForecastingDetector forecastingDetector, List<DataSourceResult> data, MetricDefinition metricDefinition) {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
+import com.expedia.adaptivealerting.anomdetect.util.DateUtil;
 import com.expedia.adaptivealerting.anomdetect.util.TimeConstantsUtil;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -46,17 +47,22 @@ public class MetrictankSource implements DataSource {
 
     private List<DataSourceResult> buildDataSourceResult(long earliestTime, long latestTime, int intervalLength, String metric) {
         List<DataSourceResult> results = new ArrayList<>();
-        for (long i = earliestTime; i < latestTime; i += TimeConstantsUtil.SECONDS_PER_DAY) {
-            List<MetrictankResult> metrictankResults = getOneDayDataFromGraphite(i, intervalLength, metric);
-            if (metrictankResults.size() > 0) {
-                String[][] dataPoints = metrictankResults.get(0).getDatapoints();
+        long earliestTimeSnappedToInterval = epochTimeSnappedToSeconds(earliestTime, intervalLength);
+        long latestTimeSnappedToInterval = epochTimeSnappedToSeconds(latestTime, intervalLength);
+
+        for (long i = earliestTimeSnappedToInterval; i < latestTimeSnappedToInterval; i += TimeConstantsUtil.SECONDS_PER_DAY) {
+            List<MetrictankResult> graphiteResults = getOneDayDataFromGraphite(i, intervalLength, metric);
+
+            if (graphiteResults.size() > 0) {
+                String[][] dataPoints = graphiteResults.get(0).getDatapoints();
                 //TODO Convert this to use JAVA stream
-                for (String[] dataPoint : dataPoints) {
+                // We discard the last data point to ensure current bin is not included in Graphite data retrieval.
+                for (int j = 0; j < dataPoints.length - 1; j++) {
                     Double value = MISSING_VALUE;
-                    if (dataPoint[0] != null) {
-                        value = Double.parseDouble(dataPoint[0]);
+                    if (dataPoints[j][0] != null) {
+                        value = Double.parseDouble(dataPoints[j][0]);
                     }
-                    long epochSeconds = Long.parseLong(dataPoint[1]);
+                    long epochSeconds = Long.parseLong(dataPoints[j][1]);
                     DataSourceResult result = new DataSourceResult(value, epochSeconds);
                     results.add(result);
                 }
@@ -89,4 +95,7 @@ public class MetrictankSource implements DataSource {
         }
     }
 
+    private long epochTimeSnappedToSeconds(long time, int seconds) {
+        return DateUtil.snapToSeconds(ofEpochSecond(time), seconds).getEpochSecond();
+    }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
@@ -75,9 +75,11 @@ public class MetrictankSource implements DataSource {
     private List<MetrictankResult> getOneDayDataFromGraphite(long from, int intervalLength, String metric) {
         // TODO: Ensure until is never greater than current metric's timestamp
         long until = from + TimeConstantsUtil.SECONDS_PER_DAY;
+        // We subtract 1 second from FROM time to get complete data from Graphite. Graphite for some reason gives incomplete data if we don't do this.
+        long fromMinusOneSecond = from - 1;
         log.debug("Querying Metric tank with: from={} ({}), until={} ({}), metric='{}'",
-                from, ofEpochSecond(from), until, ofEpochSecond(until), metric);
-        return metricTankClient.getData(from, until, intervalLength, metric);
+                from, ofEpochSecond(fromMinusOneSecond), until, ofEpochSecond(until), metric);
+        return metricTankClient.getData(fromMinusOneSecond, until, intervalLength, metric);
     }
 
     private void logResults(List<DataSourceResult> results) {

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
@@ -75,7 +75,7 @@ public class MetrictankSource implements DataSource {
     private List<MetrictankResult> getOneDayDataFromGraphite(long from, int intervalLength, String metric) {
         // TODO: Ensure until is never greater than current metric's timestamp
         long until = from + TimeConstantsUtil.SECONDS_PER_DAY;
-        // We subtract 1 second from FROM time to get complete data from Graphite. Graphite for some reason gives incomplete data if we don't do this.
+        // We subtract 1 second from FROM time to get complete data for the first bin from Graphite. Graphite for some reason gives incomplete data for first bin if we don't do this.
         long fromMinusOneSecond = from - 1;
         log.debug("Querying Metric tank with: from={} ({}), until={} ({}), metric='{}'",
                 from, ofEpochSecond(fromMinusOneSecond), until, ofEpochSecond(until), metric);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSource.java
@@ -75,7 +75,7 @@ public class MetrictankSource implements DataSource {
     private List<MetrictankResult> getOneDayDataFromGraphite(long from, int intervalLength, String metric) {
         // TODO: Ensure until is never greater than current metric's timestamp
         long until = from + TimeConstantsUtil.SECONDS_PER_DAY;
-        log.debug("Querying Metrictank with: from={} ({}), until={} ({}), metric='{}'",
+        log.debug("Querying Metric tank with: from={} ({}), until={} ({}), metric='{}'",
                 from, ofEpochSecond(from), until, ofEpochSecond(until), metric);
         return metricTankClient.getData(from, until, intervalLength, metric);
     }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DateUtil.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/DateUtil.java
@@ -54,4 +54,23 @@ public class DateUtil {
         final DayOfWeek dow = ZonedDateTime.ofInstant(date, ZoneOffset.UTC).getDayOfWeek();
         return truncatedToDay(date).minus(Duration.ofDays(dow.getValue() % 7));
     }
+
+    /**
+     * Returns the time snapped to provided seconds
+     *
+     * @param date    A date.
+     * @param seconds No of seconds
+     * @return Time snapped to seconds
+     */
+    public static Instant snapToSeconds(Instant date, int seconds) {
+        notNull(date, "date can't be null");
+        Instant instantSnapToSeconds = truncatedToSeconds(date);
+        long remainder = instantSnapToSeconds.getEpochSecond() % seconds;
+        return truncatedToSeconds(date.minusSeconds(remainder));
+    }
+
+    public static Instant truncatedToSeconds(Instant date) {
+        notNull(date, "date can't be null");
+        return date.truncatedTo(ChronoUnit.SECONDS);
+    }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ import static org.mockito.Mockito.when;
 public class MetrictankSourceTest {
 
     @Mock
-    private MetrictankClient metricTankClient;
+    private MetrictankClient metrictankClient;
 
     private MetrictankSource sourceUnderTest;
     private List<MetrictankResult> metrictankResults = new ArrayList<>();
@@ -29,72 +30,72 @@ public class MetrictankSourceTest {
         MockitoAnnotations.initMocks(this);
         initTestObjects();
         initDependencies();
-        this.sourceUnderTest = new MetrictankSource(metricTankClient);
+        this.sourceUnderTest = new MetrictankSource(metrictankClient);
     }
 
     @Test
     public void testGetMetricData() {
         val dataSourceResults = buildDataSourceResults(7);
-        val actual = sourceUnderTest.getMetricData(1580297095, 1580901895, intervalLength, "metric_name");
+        val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-08T01:09:55Z"), intervalLength, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_time_window_less_than_day() {
         val dataSourceResults = buildDataSourceResults(1);
-        val actual = sourceUnderTest.getMetricData(1580297095, 1580340295, intervalLength, "metric_name");
+        val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-02T00:09:55Z"), intervalLength, "metric_name");
         assertEquals(dataSourceResults, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, intervalLength, "null_metric");
+        val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        val actual = sourceUnderTest.getMetricData(1580815495, 1580901895, intervalLength, "null_value");
-        val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, 1578307488);
+        val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value");
+        val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, stringToEpochSeconds("2018-04-01T01:05:00Z"));
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         dataSourceResults.add(dataSourceResult);
         assertEquals(dataSourceResults, actual);
     }
 
     private void initTestObjects() {
-        metrictankResults.add(buildGraphiteResult());
-        metrictankResults_null.add(buildNullValueGraphiteResult());
+        metrictankResults.add(buildMetrictankResult());
+        metrictankResults_null.add(buildNullValueMetrictankResult());
     }
 
     private void initDependencies() {
-        when(metricTankClient.getData(1580297095, 1580383495, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580383495, 1580469895, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580469895, 1580556295, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580556295, 1580642695, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580642695, 1580729095, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580729095, 1580815495, intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metricTankClient.getData(1580815495, 1580901895, intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
 
-        when(metricTankClient.getData(1580297095, 1580383495, intervalLength, "metric_name")).thenReturn(metrictankResults);
-
-        when(metricTankClient.getData(1580815495, 1580901895, intervalLength, "null_metric")).thenReturn(new ArrayList<>());
-        when(metricTankClient.getData(1580815495, 1580901895, intervalLength, "null_value")).thenReturn(metrictankResults_null);
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(metrictankResults_null);
     }
 
-    private MetrictankResult buildGraphiteResult() {
+    private MetrictankResult buildMetrictankResult() {
         MetrictankResult metricTankResult = new MetrictankResult();
         String[][] dataPoints = {
-                {"1", "1578307488"},
-                {"3", "1578307489"}
+                {"1", "1522544700"},
+                {"3", "1523144900"},
+                {"5", "1523149500"}
         };
         metricTankResult.setDatapoints(dataPoints);
         return metricTankResult;
     }
 
-    private MetrictankResult buildNullValueGraphiteResult() {
+    private MetrictankResult buildNullValueMetrictankResult() {
         MetrictankResult metricTankResult = new MetrictankResult();
         String[][] dataPoints = {
-                {null, "1578307488"}
+                {null, "1522544700"},
+                {null, "1523144900"}
         };
         metricTankResult.setDatapoints(dataPoints);
         return metricTankResult;
@@ -104,8 +105,8 @@ public class MetrictankSourceTest {
 
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
         for (int i = 0; i < noOfResults; i++) {
-            dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
-            dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+            dataSourceResults.add(buildDataSourceResult(1.0, 1522544700));
+            dataSourceResults.add(buildDataSourceResult(3.0, 1523144900));
         }
         return dataSourceResults;
     }
@@ -115,6 +116,10 @@ public class MetrictankSourceTest {
         dataSourceResult.setDataPoint(value);
         dataSourceResult.setEpochSecond(epochSecs);
         return dataSourceResult;
+    }
+
+    private long stringToEpochSeconds(String time) {
+        return Instant.parse(time).getEpochSecond();
     }
 
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
@@ -2,6 +2,7 @@ package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
 import com.expedia.adaptivealerting.anomdetect.util.TimeConstantsUtil;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,78 +16,105 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+@Slf4j
 public class MetrictankSourceTest {
 
     @Mock
     private MetrictankClient metrictankClient;
 
     private MetrictankSource sourceUnderTest;
-    private List<MetrictankResult> metrictankResults = new ArrayList<>();
     private List<MetrictankResult> metrictankResults_null = new ArrayList<>();
     private int intervalLength = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
+    private int noOfBinsInADay;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         initTestObjects();
-        initDependencies();
         this.sourceUnderTest = new MetrictankSource(metrictankClient);
     }
 
     @Test
-    public void testGetMetricData() {
-        val dataSourceResults = buildDataSourceResults(7);
+    public void testGetMetricData_seven_days() {
+
+        List<MetrictankResult> resultsFirstDay = new ArrayList<>();
+        resultsFirstDay.add(buildMetrictankResult("2018-04-01T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+
+        List<MetrictankResult> resultsSecondDay = new ArrayList<>();
+        resultsSecondDay.add(buildMetrictankResult("2018-04-02T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSecondDay);
+
+        List<MetrictankResult> resultsThirdDay = new ArrayList<>();
+        resultsThirdDay.add(buildMetrictankResult("2018-04-03T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsThirdDay);
+
+        List<MetrictankResult> resultsFourthDay = new ArrayList<>();
+        resultsFourthDay.add(buildMetrictankResult("2018-04-04T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFourthDay);
+
+        List<MetrictankResult> resultsFifthDay = new ArrayList<>();
+        resultsFifthDay.add(buildMetrictankResult("2018-04-05T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFifthDay);
+
+        List<MetrictankResult> resultsSixthDay = new ArrayList<>();
+        resultsSixthDay.add(buildMetrictankResult("2018-04-06T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSixthDay);
+
+        List<MetrictankResult> resultsSeventhDay = new ArrayList<>();
+        resultsSeventhDay.add(buildMetrictankResult("2018-04-07T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSeventhDay);
+
+        val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-08T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-08T01:09:55Z"), intervalLength, "metric_name");
-        assertEquals(dataSourceResults, actual);
+        assertEquals(expected, actual);
+        assertEquals(noOfBinsInADay * 7, actual.size());
     }
 
     @Test
     public void testGetMetricData_time_window_less_than_day() {
-        val dataSourceResults = buildDataSourceResults(1);
+
+        List<MetrictankResult> resultsFirstDay = new ArrayList<>();
+        resultsFirstDay.add(buildMetrictankResult("2018-04-01T01:05:00Z"));
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+
+        val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-02T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-02T00:09:55Z"), intervalLength, "metric_name");
-        assertEquals(dataSourceResults, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testGetMetricData_null_metric_data() {
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
+        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(metrictankResults_null);
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value");
         val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, stringToEpochSeconds("2018-04-01T01:05:00Z"));
-        List<DataSourceResult> dataSourceResults = new ArrayList<>();
-        dataSourceResults.add(dataSourceResult);
-        assertEquals(dataSourceResults, actual);
+        List<DataSourceResult> expected = new ArrayList<>();
+        expected.add(dataSourceResult);
+        assertEquals(expected, actual);
     }
 
     private void initTestObjects() {
-        metrictankResults.add(buildMetrictankResult());
         metrictankResults_null.add(buildNullValueMetrictankResult());
+        noOfBinsInADay = getBinsInDay(intervalLength);
     }
 
-    private void initDependencies() {
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(metrictankResults);
-
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(metrictankResults_null);
-    }
-
-    private MetrictankResult buildMetrictankResult() {
+    private MetrictankResult buildMetrictankResult(String time) {
+        long earliest = stringToEpochSeconds(time);
+        //For testing, we return an extra data point to see if graphite source discards it or not.
+        String[][] dataPoints = new String[noOfBinsInADay + 1][2];
+        for (int i = 0; i < dataPoints.length; i++) {
+            dataPoints[i][0] = String.valueOf(i);
+            dataPoints[i][1] = String.valueOf(earliest);
+            earliest = earliest + intervalLength;
+        }
         MetrictankResult metricTankResult = new MetrictankResult();
-        String[][] dataPoints = {
-                {"1", "1522544700"},
-                {"3", "1523144900"},
-                {"5", "1523149500"}
-        };
         metricTankResult.setDatapoints(dataPoints);
         return metricTankResult;
     }
@@ -101,12 +129,15 @@ public class MetrictankSourceTest {
         return metricTankResult;
     }
 
-    private List<DataSourceResult> buildDataSourceResults(int noOfResults) {
-
+    private List<DataSourceResult> buildDataSourceResults(String earliestTime, String latestTime) {
         List<DataSourceResult> dataSourceResults = new ArrayList<>();
-        for (int i = 0; i < noOfResults; i++) {
-            dataSourceResults.add(buildDataSourceResult(1.0, 1522544700));
-            dataSourceResults.add(buildDataSourceResult(3.0, 1523144900));
+        int value = 0;
+        for (long i = stringToEpochSeconds(earliestTime); i < stringToEpochSeconds(latestTime); i += intervalLength) {
+            if (value > noOfBinsInADay - 1) {
+                value = 0;
+            }
+            dataSourceResults.add(buildDataSourceResult(Double.valueOf(value), i));
+            value++;
         }
         return dataSourceResults;
     }
@@ -122,4 +153,7 @@ public class MetrictankSourceTest {
         return Instant.parse(time).getEpochSecond();
     }
 
+    private int getBinsInDay(int intervalLength) {
+        return TimeConstantsUtil.SECONDS_PER_DAY / intervalLength;
+    }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
@@ -14,6 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @Slf4j
@@ -39,31 +42,31 @@ public class MetrictankSourceTest {
 
         List<MetrictankResult> resultsFirstDay = new ArrayList<>();
         resultsFirstDay.add(buildResult("2018-04-01T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:04:59Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
 
         List<MetrictankResult> resultsSecondDay = new ArrayList<>();
         resultsSecondDay.add(buildResult("2018-04-02T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSecondDay);
+        when(client.getData(stringToEpochSeconds("2018-04-02T01:04:59Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSecondDay);
 
         List<MetrictankResult> resultsThirdDay = new ArrayList<>();
         resultsThirdDay.add(buildResult("2018-04-03T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsThirdDay);
+        when(client.getData(stringToEpochSeconds("2018-04-03T01:04:59Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsThirdDay);
 
         List<MetrictankResult> resultsFourthDay = new ArrayList<>();
         resultsFourthDay.add(buildResult("2018-04-04T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFourthDay);
+        when(client.getData(stringToEpochSeconds("2018-04-04T01:04:59Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFourthDay);
 
         List<MetrictankResult> resultsFifthDay = new ArrayList<>();
         resultsFifthDay.add(buildResult("2018-04-05T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFifthDay);
+        when(client.getData(stringToEpochSeconds("2018-04-05T01:04:59Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFifthDay);
 
         List<MetrictankResult> resultsSixthDay = new ArrayList<>();
         resultsSixthDay.add(buildResult("2018-04-06T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSixthDay);
+        when(client.getData(stringToEpochSeconds("2018-04-06T01:04:59Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSixthDay);
 
         List<MetrictankResult> resultsSeventhDay = new ArrayList<>();
         resultsSeventhDay.add(buildResult("2018-04-07T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSeventhDay);
+        when(client.getData(stringToEpochSeconds("2018-04-07T01:04:59Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSeventhDay);
 
         val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-08T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-08T01:09:55Z"), intervalLength, "metric_name");
@@ -76,7 +79,7 @@ public class MetrictankSourceTest {
 
         List<MetrictankResult> resultsFirstDay = new ArrayList<>();
         resultsFirstDay.add(buildResult("2018-04-01T01:05:00Z"));
-        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:04:59Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
 
         val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-02T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-02T00:09:55Z"), intervalLength, "metric_name");
@@ -85,14 +88,14 @@ public class MetrictankSourceTest {
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:04:59Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(results_null);
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:04:59Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(results_null);
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value");
         val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, stringToEpochSeconds("2018-04-01T01:05:00Z"));
         List<DataSourceResult> expected = new ArrayList<>();

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.when;
 public class MetrictankSourceTest {
 
     @Mock
-    private MetrictankClient metrictankClient;
+    private MetrictankClient client;
 
     private MetrictankSource sourceUnderTest;
-    private List<MetrictankResult> metrictankResults_null = new ArrayList<>();
+    private List<MetrictankResult> results_null = new ArrayList<>();
     private int intervalLength = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
     private int noOfBinsInADay;
 
@@ -31,39 +31,39 @@ public class MetrictankSourceTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         initTestObjects();
-        this.sourceUnderTest = new MetrictankSource(metrictankClient);
+        this.sourceUnderTest = new MetrictankSource(client);
     }
 
     @Test
     public void testGetMetricData_seven_days() {
 
         List<MetrictankResult> resultsFirstDay = new ArrayList<>();
-        resultsFirstDay.add(buildMetrictankResult("2018-04-01T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+        resultsFirstDay.add(buildResult("2018-04-01T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
 
         List<MetrictankResult> resultsSecondDay = new ArrayList<>();
-        resultsSecondDay.add(buildMetrictankResult("2018-04-02T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSecondDay);
+        resultsSecondDay.add(buildResult("2018-04-02T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-02T01:05:00Z"), stringToEpochSeconds("2018-04-03T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSecondDay);
 
         List<MetrictankResult> resultsThirdDay = new ArrayList<>();
-        resultsThirdDay.add(buildMetrictankResult("2018-04-03T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsThirdDay);
+        resultsThirdDay.add(buildResult("2018-04-03T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-03T01:05:00Z"), stringToEpochSeconds("2018-04-04T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsThirdDay);
 
         List<MetrictankResult> resultsFourthDay = new ArrayList<>();
-        resultsFourthDay.add(buildMetrictankResult("2018-04-04T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFourthDay);
+        resultsFourthDay.add(buildResult("2018-04-04T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-04T01:05:00Z"), stringToEpochSeconds("2018-04-05T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFourthDay);
 
         List<MetrictankResult> resultsFifthDay = new ArrayList<>();
-        resultsFifthDay.add(buildMetrictankResult("2018-04-05T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFifthDay);
+        resultsFifthDay.add(buildResult("2018-04-05T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-05T01:05:00Z"), stringToEpochSeconds("2018-04-06T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFifthDay);
 
         List<MetrictankResult> resultsSixthDay = new ArrayList<>();
-        resultsSixthDay.add(buildMetrictankResult("2018-04-06T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSixthDay);
+        resultsSixthDay.add(buildResult("2018-04-06T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-06T01:05:00Z"), stringToEpochSeconds("2018-04-07T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSixthDay);
 
         List<MetrictankResult> resultsSeventhDay = new ArrayList<>();
-        resultsSeventhDay.add(buildMetrictankResult("2018-04-07T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSeventhDay);
+        resultsSeventhDay.add(buildResult("2018-04-07T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-07T01:05:00Z"), stringToEpochSeconds("2018-04-08T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsSeventhDay);
 
         val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-08T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-08T01:09:55Z"), intervalLength, "metric_name");
@@ -75,8 +75,8 @@ public class MetrictankSourceTest {
     public void testGetMetricData_time_window_less_than_day() {
 
         List<MetrictankResult> resultsFirstDay = new ArrayList<>();
-        resultsFirstDay.add(buildMetrictankResult("2018-04-01T01:05:00Z"));
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
+        resultsFirstDay.add(buildResult("2018-04-01T01:05:00Z"));
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "metric_name")).thenReturn(resultsFirstDay);
 
         val expected = buildDataSourceResults("2018-04-01T01:05:00Z", "2018-04-02T01:05:00Z");
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:09:55Z"), stringToEpochSeconds("2018-04-02T00:09:55Z"), intervalLength, "metric_name");
@@ -85,14 +85,14 @@ public class MetrictankSourceTest {
 
     @Test
     public void testGetMetricData_null_metric_data() {
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric")).thenReturn(new ArrayList<>());
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_metric");
         assertEquals(new ArrayList<>(), actual);
     }
 
     @Test
     public void testGetMetricData_null_value() {
-        when(metrictankClient.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(metrictankResults_null);
+        when(client.getData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value")).thenReturn(results_null);
         val actual = sourceUnderTest.getMetricData(stringToEpochSeconds("2018-04-01T01:05:00Z"), stringToEpochSeconds("2018-04-02T01:05:00Z"), intervalLength, "null_value");
         val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, stringToEpochSeconds("2018-04-01T01:05:00Z"));
         List<DataSourceResult> expected = new ArrayList<>();
@@ -101,11 +101,11 @@ public class MetrictankSourceTest {
     }
 
     private void initTestObjects() {
-        metrictankResults_null.add(buildNullValueMetrictankResult());
+        results_null.add(buildNullValueResult());
         noOfBinsInADay = getBinsInDay(intervalLength);
     }
 
-    private MetrictankResult buildMetrictankResult(String time) {
+    private MetrictankResult buildResult(String time) {
         long earliest = stringToEpochSeconds(time);
         //For testing, we return an extra data point to see if graphite source discards it or not.
         String[][] dataPoints = new String[noOfBinsInADay + 1][2];
@@ -114,19 +114,19 @@ public class MetrictankSourceTest {
             dataPoints[i][1] = String.valueOf(earliest);
             earliest = earliest + intervalLength;
         }
-        MetrictankResult metricTankResult = new MetrictankResult();
-        metricTankResult.setDatapoints(dataPoints);
-        return metricTankResult;
+        MetrictankResult result = new MetrictankResult();
+        result.setDatapoints(dataPoints);
+        return result;
     }
 
-    private MetrictankResult buildNullValueMetrictankResult() {
-        MetrictankResult metricTankResult = new MetrictankResult();
+    private MetrictankResult buildNullValueResult() {
+        MetrictankResult result = new MetrictankResult();
         String[][] dataPoints = {
                 {null, "1522544700"},
                 {null, "1523144900"}
         };
-        metricTankResult.setDatapoints(dataPoints);
-        return metricTankResult;
+        result.setDatapoints(dataPoints);
+        return result;
     }
 
     private List<DataSourceResult> buildDataSourceResults(String earliestTime, String latestTime) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/metrictank/MetrictankSourceTest.java
@@ -14,9 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @Slf4j

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
@@ -61,7 +61,13 @@ public final class DateUtilTest {
         doTestSnappedToSeconds("2018-04-01T01:05:51Z", "2018-04-01T01:05:00Z", 300);
 
         doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:00Z", 60);
+        doTestSnappedToSeconds("2018-04-01T01:07:05Z", "2018-04-01T01:07:00Z", 60);
+        doTestSnappedToSeconds("2018-04-01T01:07:30Z", "2018-04-01T01:07:00Z", 60);
+
         doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:30Z", 30);
+        doTestSnappedToSeconds("2018-04-01T01:07:35Z", "2018-04-01T01:07:30Z", 30);
+        doTestSnappedToSeconds("2018-04-01T01:07:05Z", "2018-04-01T01:07:00Z", 30);
+
     }
 
     @Test

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
@@ -54,6 +54,20 @@ public final class DateUtilTest {
         doTestTruncatedToWeek("2018-04-09T00:00:00Z", "2018-04-08T00:00:00Z");
     }
 
+    @Test
+    public void testSnapToSeconds() {
+        doTestSnappedToSeconds("2018-04-01T01:09:55Z", "2018-04-01T01:05:00Z", 300);
+        doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:00Z", 60);
+        doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:30Z", 30);
+    }
+
+    @Test
+    public void testTruncatedToSeconds() {
+        doTestTruncatedToSeconds("2018-04-01T09:24:54.63Z", "2018-04-01T09:24:54.00Z");
+        doTestTruncatedToSeconds("2018-04-01T09:24:54.01Z", "2018-04-01T09:24:54.00Z");
+        doTestTruncatedToSeconds("2018-04-01T09:24:53.41Z", "2018-04-01T09:24:53.00Z");
+    }
+
     private void doTestTruncatedToDay(String dateStr, String expectedStr) {
         final Instant date = Instant.parse(dateStr);
         final Instant day = Instant.parse(expectedStr);
@@ -65,6 +79,20 @@ public final class DateUtilTest {
         final Instant date = Instant.parse(dateStr);
         final Instant day = Instant.parse(expectedStr);
         final Instant actual = DateUtil.truncatedToWeek(date);
+        assertEquals(day, actual);
+    }
+
+    private void doTestSnappedToSeconds(String dateStr, String expectedStr, int seconds) {
+        final Instant expected = Instant.parse(expectedStr);
+        final Instant date = Instant.parse(dateStr);
+        final Instant actual = DateUtil.snapToSeconds(date, seconds);
+        assertEquals(expected, actual);
+    }
+
+    private void doTestTruncatedToSeconds(String dateStr, String expectedStr) {
+        final Instant date = Instant.parse(dateStr);
+        final Instant day = Instant.parse(expectedStr);
+        final Instant actual = DateUtil.truncatedToSeconds(date);
         assertEquals(day, actual);
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/DateUtilTest.java
@@ -57,6 +57,9 @@ public final class DateUtilTest {
     @Test
     public void testSnapToSeconds() {
         doTestSnappedToSeconds("2018-04-01T01:09:55Z", "2018-04-01T01:05:00Z", 300);
+        doTestSnappedToSeconds("2018-04-01T01:07:15Z", "2018-04-01T01:05:00Z", 300);
+        doTestSnappedToSeconds("2018-04-01T01:05:51Z", "2018-04-01T01:05:00Z", 300);
+
         doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:00Z", 60);
         doTestSnappedToSeconds("2018-04-01T01:07:55Z", "2018-04-01T01:07:30Z", 30);
     }


### PR DESCRIPTION
This PR addresses a couple of issues we were experiencing while querying graphite:
1) We are now snapping earliest & latest time to interval length and moved the snap logic to date util class.
2) We are now discarding the last data point to ensure the current bin is not included in Graphite response.
3) We deduct 1 second from FROM time to ensure the first bin is not incomplete. 


```020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522544700 (2018-04-01T01:04:59Z), until=1522631100 (2018-04-02T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522631100 (2018-04-02T01:04:59Z), until=1522717500 (2018-04-03T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522717500 (2018-04-03T01:04:59Z), until=1522803900 (2018-04-04T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522803900 (2018-04-04T01:04:59Z), until=1522890300 (2018-04-05T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522890300 (2018-04-05T01:04:59Z), until=1522976700 (2018-04-06T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1522976700 (2018-04-06T01:04:59Z), until=1523063100 (2018-04-07T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:80 () - Querying Metric tank with: from=1523063100 (2018-04-07T01:04:59Z), until=1523149500 (2018-04-08T01:05:00Z), metric='metric_name'
2020-02-17 12:42:43 DEBUG MetrictankSource:91 () - Retrieved 2016 data points from Graphite from 1522544700 (2018-04-01T01:05:00Z) until 1523149200 (2018-04-08T01:00:00Z)