### PR TITLE
Renamed metrictank to graphite

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientException.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientException.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
+package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
-public class MetrictankClientException extends RuntimeException {
-    public MetrictankClientException(String message, Exception cause) {
+public class GraphiteClientException extends RuntimeException {
+    public GraphiteClientException(String message, Exception cause) {
         super(message, cause);
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteResult.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteResult.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
+package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
@@ -26,7 +26,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MetrictankResult {
+public class GraphiteResult {
     private String[][] datapoints;
     private String target;
     private Map<String, Object> tags;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
+package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
@@ -30,7 +30,7 @@ import static java.time.Instant.ofEpochSecond;
 
 @RequiredArgsConstructor
 @Slf4j
-public class MetrictankSource implements DataSource {
+public class GraphiteSource implements DataSource {
 
     public static final Double MISSING_VALUE = Double.NEGATIVE_INFINITY;
 
@@ -38,7 +38,7 @@ public class MetrictankSource implements DataSource {
      * Client to load metric data from graphite.
      */
     @NonNull
-    private MetrictankClient metricTankClient;
+    private GraphiteClient graphiteClient;
 
     @Override
     public List<DataSourceResult> getMetricData(long earliestTime, long latestTime, int intervalLength, String target) {
@@ -51,7 +51,7 @@ public class MetrictankSource implements DataSource {
         long latestTimeSnappedToInterval = epochTimeSnappedToSeconds(latestTime, intervalLength);
 
         for (long i = earliestTimeSnappedToInterval; i < latestTimeSnappedToInterval; i += TimeConstantsUtil.SECONDS_PER_DAY) {
-            List<MetrictankResult> graphiteResults = getOneDayDataFromGraphite(i, intervalLength, metric);
+            List<GraphiteResult> graphiteResults = getOneDayDataFromGraphite(i, intervalLength, metric);
 
             if (graphiteResults.size() > 0) {
                 String[][] dataPoints = graphiteResults.get(0).getDatapoints();
@@ -72,14 +72,14 @@ public class MetrictankSource implements DataSource {
         return results;
     }
 
-    private List<MetrictankResult> getOneDayDataFromGraphite(long from, int intervalLength, String metric) {
+    private List<GraphiteResult> getOneDayDataFromGraphite(long from, int intervalLength, String metric) {
         // TODO: Ensure until is never greater than current metric's timestamp
         long until = from + TimeConstantsUtil.SECONDS_PER_DAY;
         // We subtract 1 second from FROM time to get complete data for the first bin from Graphite. Graphite for some reason gives incomplete data for first bin if we don't do this.
         long fromMinusOneSecond = from - 1;
-        log.debug("Querying Metric tank with: from={} ({}), until={} ({}), metric='{}'",
+        log.debug("Querying Graphite with: from={} ({}), until={} ({}), metric='{}'",
                 fromMinusOneSecond, ofEpochSecond(fromMinusOneSecond), until, ofEpochSecond(until), metric);
-        return metricTankClient.getData(fromMinusOneSecond, until, intervalLength, metric);
+        return graphiteClient.getData(fromMinusOneSecond, until, intervalLength, metric);
     }
 
     private void logResults(List<DataSourceResult> results) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteClientTest.java
@@ -1,4 +1,4 @@
-package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
+package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,12 +13,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import static com.expedia.adaptivealerting.anomdetect.source.data.metrictank.MetrictankClient.FETCH_METRICS_PATH;
+import static com.expedia.adaptivealerting.anomdetect.source.data.graphite.GraphiteClient.FETCH_METRICS_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @Slf4j
-public class MetrictankClientTest {
+public class GraphiteClientTest {
     private static final String BASE_URI = "http://graphite";
     private static final String METRIC_URI = fetchMetricsUri("metricName");
     private static final String METRIC_URI_CANT_GET = fetchMetricsUri("metricNameCantGet");
@@ -28,7 +28,7 @@ public class MetrictankClientTest {
     private static final int UNTIL_TIME_IN_SECONDS = FROM_TIME_IN_SECONDS + ONE_DAY_IN_SECONDS;
     private static final int INTERVAL_LENGTH = 60;
 
-    private MetrictankClient clientUnderTest;
+    private GraphiteClient clientUnderTest;
 
     @Mock
     private HttpClientWrapper httpClient;
@@ -45,14 +45,14 @@ public class MetrictankClientTest {
     private byte[] docsBytes = "docsBytes".getBytes();
 
     private byte[] docBytes_cantRead = "docBytes_cantRead".getBytes();
-    private MetrictankResult[] docs = {};
+    private GraphiteResult[] docs = {};
     private Map<String, String> headers = Collections.singletonMap("x-org-id", "1");
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         initMetricData();
-        this.clientUnderTest = new MetrictankClient(BASE_URI, httpClient, objectMapper);
+        this.clientUnderTest = new GraphiteClient(BASE_URI, httpClient, objectMapper);
     }
 
     @Test
@@ -61,12 +61,12 @@ public class MetrictankClientTest {
         clientUnderTest.getData(FROM_TIME_IN_SECONDS, UNTIL_TIME_IN_SECONDS, INTERVAL_LENGTH, "metricName");
     }
 
-    @Test(expected = MetrictankClientException.class)
+    @Test(expected = GraphiteClientException.class)
     public void testGetMetricData_cant_get() {
         clientUnderTest.getData(FROM_TIME_IN_SECONDS, UNTIL_TIME_IN_SECONDS, INTERVAL_LENGTH, "metricNameCantGet");
     }
 
-    @Test(expected = MetrictankClientException.class)
+    @Test(expected = GraphiteClientException.class)
     public void testGetMetricData_cant_read() {
         clientUnderTest.getData(FROM_TIME_IN_SECONDS, UNTIL_TIME_IN_SECONDS, INTERVAL_LENGTH, "metricNameCantRead");
     }
@@ -74,13 +74,13 @@ public class MetrictankClientTest {
     private void initMetricData() throws IOException {
         when(httpClient.get(METRIC_URI, headers)).thenReturn(docsContent);
         when(docsContent.asBytes()).thenReturn(docsBytes);
-        when(objectMapper.readValue(docsBytes, MetrictankResult[].class)).thenReturn(docs);
+        when(objectMapper.readValue(docsBytes, GraphiteResult[].class)).thenReturn(docs);
 
         when(httpClient.get(METRIC_URI_CANT_GET, headers)).thenThrow(new IOException());
 
         when(httpClient.get(METRIC_URI_CANT_READ, headers)).thenReturn(docContent_cantRead);
         when(docContent_cantRead.asBytes()).thenReturn(docBytes_cantRead);
-        when(objectMapper.readValue(docBytes_cantRead, MetrictankResult[].class)).thenThrow(new IOException());
+        when(objectMapper.readValue(docBytes_cantRead, GraphiteResult[].class)).thenThrow(new IOException());
     }
 
 

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/graphite/GraphiteSourceTest.java
@@ -1,4 +1,4 @@
-package com.expedia.adaptivealerting.anomdetect.source.data.metrictank;
+package com.expedia.adaptivealerting.anomdetect.source.data.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
 import com.expedia.adaptivealerting.anomdetect.util.TimeConstantsUtil;
@@ -20,28 +20,28 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @Slf4j
-public class MetrictankSourceTest {
+public class GraphiteSourceTest {
 
     private static final String EARLIEST_TIME = "2018-04-01T01:05:00Z";
 
     @Mock
-    private MetrictankClient client;
+    private GraphiteClient client;
 
-    private MetrictankSource sourceUnderTest;
+    private GraphiteSource sourceUnderTest;
 
     private long earliestTimeInEpoch;
     private int intervalLength = 5 * TimeConstantsUtil.SECONDS_PER_MIN;
     private int noOfBinsInADay;
 
-    private List<MetrictankResult> metrictankResults = new ArrayList<>();
-    private List<MetrictankResult> metrictankResults_null = new ArrayList<>();
+    private List<GraphiteResult> graphiteResults = new ArrayList<>();
+    private List<GraphiteResult> graphiteResults_null = new ArrayList<>();
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         initTestObjects();
         initDependencies();
-        this.sourceUnderTest = new MetrictankSource(client);
+        this.sourceUnderTest = new GraphiteSource(client);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class MetrictankSourceTest {
     public void testGetMetricData_null_value() {
         val latestTimeInEpoch = earliestTimeInEpoch + TimeConstantsUtil.SECONDS_PER_DAY;
         val actual = sourceUnderTest.getMetricData(earliestTimeInEpoch, latestTimeInEpoch, intervalLength, "null_value");
-        val dataSourceResult = buildDataSourceResult(MetrictankSource.MISSING_VALUE, earliestTimeInEpoch);
+        val dataSourceResult = buildDataSourceResult(GraphiteSource.MISSING_VALUE, earliestTimeInEpoch);
         val expected = new ArrayList<>();
         expected.add(dataSourceResult);
         assertEquals(expected, actual);
@@ -82,17 +82,17 @@ public class MetrictankSourceTest {
     private void initTestObjects() {
         earliestTimeInEpoch = Instant.parse(EARLIEST_TIME).getEpochSecond();
         noOfBinsInADay = getBinsInDay(intervalLength);
-        metrictankResults.add(buildMetrictankResult(earliestTimeInEpoch));
-        metrictankResults_null.add(buildNullMetrictankResult());
+        graphiteResults.add(buildGraphiteResult(earliestTimeInEpoch));
+        graphiteResults_null.add(buildNullGraphiteResult());
     }
 
     private void initDependencies() {
-        when(client.getData(anyLong(), anyLong(), anyInt(), eq("metric_name"))).thenReturn(metrictankResults);
+        when(client.getData(anyLong(), anyLong(), anyInt(), eq("metric_name"))).thenReturn(graphiteResults);
         when(client.getData(anyLong(), anyLong(), anyInt(), eq("null_metric"))).thenReturn(new ArrayList<>());
-        when(client.getData(anyLong(), anyLong(), anyInt(), eq("null_value"))).thenReturn(metrictankResults_null);
+        when(client.getData(anyLong(), anyLong(), anyInt(), eq("null_value"))).thenReturn(graphiteResults_null);
     }
 
-    private MetrictankResult buildMetrictankResult(long earliestTime) {
+    private GraphiteResult buildGraphiteResult(long earliestTime) {
         //For testing, we return an extra data point to see if graphite source discards it or not.
         String[][] dataPoints = new String[noOfBinsInADay + 1][2];
         for (int i = 0; i < dataPoints.length; i++) {
@@ -100,13 +100,13 @@ public class MetrictankSourceTest {
             dataPoints[i][1] = String.valueOf(earliestTime);
             earliestTime = earliestTime + intervalLength;
         }
-        MetrictankResult result = new MetrictankResult();
+        GraphiteResult result = new GraphiteResult();
         result.setDatapoints(dataPoints);
         return result;
     }
 
-    private MetrictankResult buildNullMetrictankResult() {
-        MetrictankResult result = new MetrictankResult();
+    private GraphiteResult buildNullGraphiteResult() {
+        GraphiteResult result = new GraphiteResult();
         String[][] dataPoints = {
                 {null, "1522544700"},
                 {null, "1523144900"}

--- a/kafka/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerFactory.java
+++ b/kafka/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerFactory.java
@@ -15,8 +15,8 @@
  */
 package com.expedia.adaptivealerting.anomdetect.source.data.initializer;
 
-import com.expedia.adaptivealerting.anomdetect.source.data.metrictank.MetrictankClient;
-import com.expedia.adaptivealerting.anomdetect.source.data.metrictank.MetrictankSource;
+import com.expedia.adaptivealerting.anomdetect.source.data.graphite.GraphiteClient;
+import com.expedia.adaptivealerting.anomdetect.source.data.graphite.GraphiteSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.throttlegate.RandomThrottleGate;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.throttlegate.ThrottleGate;
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
@@ -32,8 +32,8 @@ public class DataInitializerFactory {
     public static DataInitializer buildDataInitializer(Config config) {
         val throttleGate = tryCreateThrottleGate(config);
         val baseUri = config.getString(BASE_URI);
-        val metrictankClient = new MetrictankClient(baseUri, new HttpClientWrapper(), new ObjectMapper());
-        val dataSource = new MetrictankSource(metrictankClient);
+        val graphiteClient = new GraphiteClient(baseUri, new HttpClientWrapper(), new ObjectMapper());
+        val dataSource = new GraphiteSource(graphiteClient);
         return new DataInitializer(config, throttleGate, dataSource);
     }
 


### PR DESCRIPTION
Renamed metrictank to graphite to maintain the consistency.

`x-org-id is a mandatory header for metric tank. In future, we would like to make it configurable as the only difference between graphite client and metric tank client is x-org-id header.`