### PR TITLE
Creating interval for querying graphite based on current timestamp

### DIFF
--- a/deployment/terraform/aa-metric-functions/templates/aa-metric-functions_conf.tpl
+++ b/deployment/terraform/aa-metric-functions/templates/aa-metric-functions_conf.tpl
@@ -7,7 +7,7 @@ aa-metric-functions {
   }
   metric-source-sink {
     metric-source = "graphite"
-    urlTemplate: "${metric_source_graphite_host}/render?until=now&format=json&target="
+    urlTemplate: "${metric_source_graphite_host}/render?format=json&target="
     graphite-host = "${metric_source_graphite_host}"
     output_topic = "${aggregator_producer_topic}"
     is-graphite-server-metrictank = "${is_graphite_server_metrictank}"

--- a/kafka/src/main/resources/config/base.conf
+++ b/kafka/src/main/resources/config/base.conf
@@ -84,7 +84,7 @@ aa-metric-functions {
 
   metric-source-sink {
     metric-source = "graphite"
-    urlTemplate: "samplegraphitehosturi/render?until=now&format=json&target="
+    urlTemplate: "samplegraphitehosturi/render?format=json&target="
     graphite-host = "samplegraphitehosturi"
     output-topic = "aa-metrics"
   }

--- a/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/service/graphite/GraphiteQueryService.java
+++ b/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/service/graphite/GraphiteQueryService.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.metrics.functions.service.graphite;
 
 import com.expedia.adaptivealerting.anomdetect.util.HttpClientWrapper;
 import com.expedia.adaptivealerting.metrics.functions.source.MetricFunctionsSpec;
+import com.expedia.adaptivealerting.metrics.functions.source.graphite.GraphiteQueryInterval;
 import com.expedia.adaptivealerting.metrics.functions.source.graphite.GraphiteQueryResult;
 import com.expedia.adaptivealerting.metrics.functions.source.graphite.ConstructSourceURI;
 import com.expedia.metrics.MetricData;
@@ -24,7 +25,10 @@ import com.expedia.metrics.MetricDefinition;
 import com.expedia.metrics.TagCollection;
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.http.client.fluent.Content;
+
+import java.time.Instant;
 import java.util.Collections;
 
 
@@ -63,7 +67,10 @@ public class GraphiteQueryService {
     private String queryGraphiteSource(Config metricSourceSinkConfig, MetricFunctionsSpec metricFunctionsSpec) {
         try {
             ConstructSourceURI constructSourceURI = new ConstructSourceURI();
-            String URI = constructSourceURI.getGraphiteURI(metricSourceSinkConfig, metricFunctionsSpec);
+            val currentGraphiteEpochSeconds = Instant.now().getEpochSecond();
+            val intervalInSecs = metricFunctionsSpec.getIntervalInSecs();
+            GraphiteQueryInterval queryInterval = new GraphiteQueryInterval(currentGraphiteEpochSeconds, intervalInSecs);
+            String URI = constructSourceURI.getGraphiteURI(metricSourceSinkConfig, metricFunctionsSpec, queryInterval);
             Map<String, String> headers = Collections.emptyMap();
             if (metricSourceSinkConfig.getString(IS_GRAPHITE_SERVER_METRICTANK_KEY).
                     equals(GRAPHITE_SERVER_METRICTANK)) {

--- a/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/ConstructSourceURI.java
+++ b/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/ConstructSourceURI.java
@@ -20,14 +20,15 @@ import com.typesafe.config.Config;
 
 public class ConstructSourceURI {
     private final String GRAPHITE_URI_KEY = "urlTemplate";
-    private final String GRAPHITE_FROM_TIME_PARAM_STRING = "&from=-";
-    private final String GRAPHITE_TIME_UNIT_STRING = "s";
 
-    public String getGraphiteURI(Config metricSourceSinkConfig, MetricFunctionsSpec metricFunctionsSpec) {
-        return metricSourceSinkConfig.getString(GRAPHITE_URI_KEY)
-                + metricFunctionsSpec.getFunction()
-                + GRAPHITE_FROM_TIME_PARAM_STRING
-                + metricFunctionsSpec.getIntervalInSecs() + GRAPHITE_TIME_UNIT_STRING;
+    public String getGraphiteURI(Config metricSourceSinkConfig,
+                                 MetricFunctionsSpec metricFunctionsSpec,
+                                 GraphiteQueryInterval graphiteQueryInterval) {
+        String graphiteUri = metricSourceSinkConfig.getString(GRAPHITE_URI_KEY);
+        return String.format("%s%s&from=%d&until=%d",
+                graphiteUri,
+                metricFunctionsSpec.getFunction(),
+                graphiteQueryInterval.getFrom(),
+                graphiteQueryInterval.getUntil());
     }
-
 }

--- a/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/GraphiteQueryInterval.java
+++ b/metrics/src/main/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/GraphiteQueryInterval.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.metrics.functions.source.graphite;
+
+import lombok.Data;
+import lombok.val;
+
+@Data
+public class GraphiteQueryInterval {
+
+    long from;
+    long until;
+
+    public GraphiteQueryInterval(long date, long intervalInSeconds) {
+        val startOfCurrentInterval = (date / intervalInSeconds) * intervalInSeconds;
+        from = startOfCurrentInterval - 1;
+        until = startOfCurrentInterval + intervalInSeconds;
+    }
+}

--- a/metrics/src/test/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/ConstructSourceURITest.java
+++ b/metrics/src/test/java/com/expedia/adaptivealerting/metrics/functions/source/graphite/ConstructSourceURITest.java
@@ -14,12 +14,17 @@ public class ConstructSourceURITest {
     @Test
     public void testGetGraphiteURI() {
         val functionsInputFileName = "config/functions-test.txt";
-        val uri = "samplegraphitehosturi/render?until=now&format=json&target=sumSeries(a.b.c)&from=-30s";
+        val uri = "samplegraphitehosturi/render?format=json&target=sumSeries(a.b.c)&from=89&until=120";
         MetricFunctionsSpec metricFunctionsSpec = MetricFunctionsReader.
                 readFromInputFile(ClassLoader.getSystemResource(functionsInputFileName).getPath()).get(0);
         Config config = new TypesafeConfigLoader("aa-metric-functions-test").loadMergedConfig();
         val metricSourceSinkConfigTest = config.getConfig("metric-source-sink");
+
+        val currentGraphiteEpochSeconds = 100;
+        val intervalInSecs = metricFunctionsSpec.getIntervalInSecs();
+        GraphiteQueryInterval queryInterval = new GraphiteQueryInterval(currentGraphiteEpochSeconds, intervalInSecs);
+
         ConstructSourceURI constructSourceURI = new ConstructSourceURI();
-        assertEquals(uri, constructSourceURI.getGraphiteURI(metricSourceSinkConfigTest, metricFunctionsSpec));
+        assertEquals(uri, constructSourceURI.getGraphiteURI(metricSourceSinkConfigTest, metricFunctionsSpec, queryInterval));
     }
 }

--- a/metrics/src/test/resources/config/base.conf
+++ b/metrics/src/test/resources/config/base.conf
@@ -7,7 +7,7 @@ kstream.app.default {
 aa-metric-functions-test {
   metric-source-sink {
    metric-source = "graphite"
-   urlTemplate: "samplegraphitehosturi/render?until=now&format=json&target="
+   urlTemplate: "samplegraphitehosturi/render?format=json&target="
    output_topic = "aa-metrics"
    is-graphite-server-metrictank = "metrictank"
   }


### PR DESCRIPTION
Creating interval for querying graphite based on current timestamp.

When querying Graphite the FROM and UNTIL date settings must be specified precisely in order to return consistent results.
For Aggregator use the following:
FROM: (START_OF_PREVIOUS_INTERVAL - 1s)
UNTIL: START_OF_CURRENT_INTERVAL
where:
START_OF_CURRENT_INTERVAL = (<metric's timestamp> / INTERVAL) * INTERVAL
START_OF_PREVIOUS_INTERVAL = START_OF_CURRENT_INTERVAL - INTERVAL