### PR TITLE
Added change to querty graphite directly via tags

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -22,7 +22,6 @@ import com.expedia.adaptivealerting.anomdetect.detect.AnomalyLevel;
 import com.expedia.adaptivealerting.anomdetect.detect.Detector;
 import com.expedia.adaptivealerting.anomdetect.detect.DetectorResult;
 import com.expedia.adaptivealerting.anomdetect.detect.MappedMetricData;
-import com.expedia.adaptivealerting.anomdetect.mapper.ExpressionTree;
 import com.expedia.adaptivealerting.anomdetect.source.DetectorSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.DataInitializer;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.DetectorDataInitializationThrottledException;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -22,6 +22,7 @@ import com.expedia.adaptivealerting.anomdetect.detect.AnomalyLevel;
 import com.expedia.adaptivealerting.anomdetect.detect.Detector;
 import com.expedia.adaptivealerting.anomdetect.detect.DetectorResult;
 import com.expedia.adaptivealerting.anomdetect.detect.MappedMetricData;
+import com.expedia.adaptivealerting.anomdetect.mapper.ExpressionTree;
 import com.expedia.adaptivealerting.anomdetect.source.DetectorSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.DataInitializer;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.DetectorDataInitializationThrottledException;
@@ -159,6 +160,7 @@ public class DetectorManager {
     private Optional<Detector> detectorFor(MappedMetricData mappedMetricData) {
         notNull(mappedMetricData, "mappedMetricData can't be null");
         val detectorUuid = mappedMetricData.getDetectorUuid();
+
         Detector detector = cachedDetectors.get(detectorUuid);
         if (detector == null) {
             detector = detectorSource.findDetector(detectorUuid);
@@ -179,7 +181,8 @@ public class DetectorManager {
     private boolean attemptDataInitialization(MappedMetricData mappedMetricData, Detector detector) {
         boolean dataInitCompleted;
         try {
-            dataInitializer.initializeDetector(mappedMetricData, detector);
+            val detectorMapping = detectorSource.findDetectorMappingByUuid(detector.getUuid());
+            dataInitializer.initializeDetector(mappedMetricData, detector, detectorMapping);
             dataInitCompleted = true;
         } catch (DetectorDataInitializationThrottledException e) {
             log.info("Data Initialization throttled: {}", e.getMessage());
@@ -192,7 +195,7 @@ public class DetectorManager {
     }
 
     /**
-     * Sync with detector datastore by polling to get all deleted detectors
+     * Sync with detector data store by polling to get all deleted detectors
      * The deleted detectors will be cleaned up and the detectors modified will be reloaded
      * when corresponding mapped-metric comes in.
      * On successful sync update syncUptill time to currentTime

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DefaultDetectorSource.java
@@ -62,6 +62,13 @@ public class DefaultDetectorSource implements DetectorSource {
     }
 
     @Override
+    public DetectorMapping findDetectorMappingByUuid(UUID uuid) {
+        notNull(uuid, "uuid can't be null");
+        return client.findDetectorMappingByUuid(uuid);
+    }
+
+
+    @Override
     public Detector findDetector(UUID uuid) {
         notNull(uuid, "uuid can't be null");
         val document = client.findDetectorDocument(uuid);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorClient.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorClient.java
@@ -30,7 +30,6 @@ import org.apache.http.client.fluent.Content;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorSource.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/DetectorSource.java
@@ -60,6 +60,14 @@ public interface DetectorSource {
     List<DetectorMapping> findUpdatedDetectorMappings(long timePeriod);
 
     /**
+     * Finds a detector mapping for the given detector UUID
+     *
+     * @param uuid Detector UUID.
+     * @return Detector mapping
+     */
+    DetectorMapping findDetectorMappingByUuid(UUID uuid);
+
+    /**
      * Finds the detector for a given detector and, optionally, metric.
      *
      * @param uuid Detector UUID.

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -118,6 +118,15 @@ public class DataInitializer {
         return new MetricData(metricDefinition, dataPoint, epochSecond);
     }
 
+    private String getTarget(MappedMetricData mappedMetricData, DetectorMapping detectorMapping) {
+        val dataRetrievalTags = extractTagsFromExpression(detectorMapping.getExpression());
+        String target = "seriesByTag(" + dataRetrievalTags + ")";
+        if (dataRetrievalTagKey != null) {
+            target = MetricUtil.getDataRetrievalValue(mappedMetricData, dataRetrievalTagKey);
+        }
+        return target;
+    }
+
     private String extractTagsFromExpression(ExpressionTree expression) {
         val operands = expression.getOperands();
         Map<String, String> tags = new HashMap<>();
@@ -130,14 +139,5 @@ public class DataInitializer {
 
     private String convertHashMapToQueryString(Map<String, String> mapToConvert) {
         return mapToConvert.toString().replace("{", "").replace("}", "");
-    }
-
-    private String getTarget(MappedMetricData mappedMetricData, DetectorMapping detectorMapping) {
-        val dataRetrievalTags = extractTagsFromExpression(detectorMapping.getExpression());
-        String target = "seriesByTag(" + dataRetrievalTags + ")";
-        if (dataRetrievalTagKey != null) {
-            target = MetricUtil.getDataRetrievalValue(mappedMetricData, dataRetrievalTagKey);
-        }
-        return target;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -128,8 +128,8 @@ public class DataInitializer {
     }
 
     private String extractTagsFromExpression(ExpressionTree expression) {
-        val operands = expression.getOperands();
         Map<String, String> tags = new HashMap<>();
+        val operands = expression.getOperands();
         for (val operand : operands) {
             val field = operand.getField();
             tags.put("'" + field.getKey(), field.getValue() + "'");
@@ -138,6 +138,8 @@ public class DataInitializer {
     }
 
     private String convertHashMapToQueryString(Map<String, String> mapToConvert) {
-        return mapToConvert.toString().replace("{", "").replace("}", "");
+        return mapToConvert.toString()
+                .replace("{", "")
+                .replace("}", "");
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -120,6 +120,7 @@ public class DataInitializer {
 
     private String getTarget(MappedMetricData mappedMetricData, DetectorMapping detectorMapping) {
         val dataRetrievalTags = extractTagsFromExpression(detectorMapping.getExpression());
+        //FIXME WE don't want to hardcode graphite function here. Ideally this should be part of graphite client.
         String target = "seriesByTag(" + dataRetrievalTags + ")";
         if (dataRetrievalTagKey != null) {
             target = MetricUtil.getDataRetrievalValue(mappedMetricData, dataRetrievalTagKey);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializer.java
@@ -136,7 +136,7 @@ public class DataInitializer {
         val dataRetrievalTags = extractTagsFromExpression(detectorMapping.getExpression());
         String target = "seriesByTag(" + dataRetrievalTags + ")";
         if (dataRetrievalTagKey != null) {
-            target = MetricUtil.getDataRetrievalValueOrTagsList(mappedMetricData, dataRetrievalTagKey, dataRetrievalTags);
+            target = MetricUtil.getDataRetrievalValue(mappedMetricData, dataRetrievalTagKey);
         }
         return target;
     }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtil.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtil.java
@@ -105,7 +105,7 @@ public class MetricUtil {
      * @param mappedMetricData Mapped metric data
      * @return Returns value for the provided data retrieval tag key.
      */
-    public static String getDataRetrievalValueOrTagsList(MappedMetricData mappedMetricData, String dataRetrievalTagKey, String dataRetrievalTags) {
+    public static String getDataRetrievalValue(MappedMetricData mappedMetricData, String dataRetrievalTagKey) {
         val metricData = mappedMetricData.getMetricData();
         val metricDefinition = metricData.getMetricDefinition();
         val metricTags = metricDefinition.getTags();

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtil.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtil.java
@@ -101,28 +101,15 @@ public class MetricUtil {
 
     /**
      * Convenience method to get the value of the tag that has a key matching DATA_RETRIEVAL_TAG_KEY for the provided metric.
-     * If the provided metric does not contain that tag, the key of the metric's MetricDefinition will be returned.
      *
      * @param mappedMetricData Mapped metric data
-     * @return Returns value for the provided data retrieval tag key. If value is not present then the key of the metric's MetricDefinition will be returned.
+     * @return Returns value for the provided data retrieval tag key.
      */
-    public static String getDataRetrievalValueOrMetricKey(MappedMetricData mappedMetricData, String dataRetrievalTagKey) {
+    public static String getDataRetrievalValueOrTagsList(MappedMetricData mappedMetricData, String dataRetrievalTagKey, String dataRetrievalTags) {
         val metricData = mappedMetricData.getMetricData();
         val metricDefinition = metricData.getMetricDefinition();
         val metricTags = metricDefinition.getTags();
-        val metricKey = metricDefinition.getKey();
-
-        if (dataRetrievalTagKey == null) {
-            return metricKey;
-        }
-
-        val dataRetrievalTagValue = getValueFromTagKey(metricTags, dataRetrievalTagKey);
-        if (dataRetrievalTagValue != null) {
-            return dataRetrievalTagValue;
-        } else {
-            log.warn("Provided data retrieval key={} doesn't exist. Returning metric key instead", dataRetrievalTagKey);
-            return metricKey;
-        }
+        return getValueFromTagKey(metricTags, dataRetrievalTagKey);
     }
 
     private String getValueFromTagKey(TagCollection metricTags, String dataRetrievalTagKey) {

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -168,17 +168,16 @@ public class DataInitializerTest {
     }
 
     private ExpressionTree getExpression() {
-        ExpressionTree expression = new ExpressionTree();
+        val expression = new ExpressionTree();
         expression.setOperator(Operator.AND);
+        val tag1 = new Operand();
+        tag1.setField(new Field("name", "sample-app"));
+        val tag2 = new Operand();
+        tag2.setField(new Field("region", "us-west-2"));
+
         List<Operand> operands = new ArrayList<>();
-        val testOperand = new Operand();
-        testOperand.setField(new Field("name", "sample-app"));
-
-        val testOperand1 = new Operand();
-        testOperand1.setField(new Field("region", "us-west-2"));
-
-        operands.add(testOperand);
-        operands.add(testOperand1);
+        operands.add(tag1);
+        operands.add(tag2);
         expression.setOperands(operands);
         return expression;
     }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -24,12 +24,18 @@ import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.pewma.PewmaPo
 import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.pewma.PewmaPointForecasterParams;
 import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.seasonalnaive.MetricDeliveryDuplicateException;
 import com.expedia.adaptivealerting.anomdetect.forecast.point.algo.seasonalnaive.MetricDeliveryTimeException;
+import com.expedia.adaptivealerting.anomdetect.mapper.DetectorMapping;
+import com.expedia.adaptivealerting.anomdetect.mapper.ExpressionTree;
+import com.expedia.adaptivealerting.anomdetect.mapper.Field;
+import com.expedia.adaptivealerting.anomdetect.mapper.Operand;
+import com.expedia.adaptivealerting.anomdetect.mapper.Operator;
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSource;
 import com.expedia.adaptivealerting.anomdetect.source.data.DataSourceResult;
 import com.expedia.adaptivealerting.anomdetect.source.data.initializer.throttlegate.ThrottleGate;
 import com.expedia.metrics.MetricData;
 import com.expedia.metrics.MetricDefinition;
 import com.typesafe.config.Config;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +46,10 @@ import org.mockito.MockitoAnnotations;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.expedia.adaptivealerting.anomdetect.detect.AnomalyType.TWO_TAILED;
+import static com.sun.tools.classfile.AccessFlags.Kind.Field;
 import static java.util.UUID.randomUUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -51,6 +59,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 
+@Slf4j
 public class DataInitializerTest {
     @InjectMocks
     private DataInitializer initializerUnderTest;
@@ -64,6 +73,8 @@ public class DataInitializerTest {
     private ForecastingDetector seasonalNaiveDetector;
     @Mock
     private SeasonalPointForecaster seasonalPointForecaster;
+
+    private DetectorMapping detectorMapping;
 
     private MappedMetricData mappedMetricData;
     private List<DataSourceResult> dataSourceResults;
@@ -79,20 +90,20 @@ public class DataInitializerTest {
     @Test
     public void testInitializeDetectorThrottleGateOpen() {
         initThrottleGate(true);
-        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector);
+        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector, detectorMapping);
     }
 
     @Test(expected = DetectorDataInitializationThrottledException.class)
     public void testInitializeDetectorThrottleGateClosed() {
         initThrottleGate(false);
-        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector);
+        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector, detectorMapping);
     }
 
     @Test
     public void testInitializeDetectorWithDuplicateMetric() {
         when(throttleGate.isOpen()).thenReturn(true);
         doThrow(new MetricDeliveryDuplicateException("Metric with dodgy timestamp")).when(seasonalPointForecaster).forecast(any(MetricData.class));
-        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector);
+        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector, detectorMapping);
         // Assertion here is that exception is swallowed
     }
 
@@ -100,7 +111,7 @@ public class DataInitializerTest {
     public void testInitializeDetectorWithTimeException() {
         initThrottleGate(true);
         doThrow(new MetricDeliveryTimeException("Metric with dodgy timestamp")).when(seasonalPointForecaster).forecast(any(MetricData.class));
-        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector);
+        initializerUnderTest.initializeDetector(mappedMetricData, seasonalNaiveDetector, detectorMapping);
         // Assertion here is that exception is swallowed
     }
 
@@ -111,7 +122,7 @@ public class DataInitializerTest {
         val pointForecaster = new PewmaPointForecaster(pointParams);
         val intervalForecaster = new MultiplicativeIntervalForecaster(intervalParams);
         val detector = new ForecastingDetector(randomUUID(), pointForecaster, intervalForecaster, TWO_TAILED, true, "seasonalnaive");
-        initializerUnderTest.initializeDetector(mappedMetricData, detector);
+        initializerUnderTest.initializeDetector(mappedMetricData, detector, detectorMapping);
     }
 
     private void initConfig() {
@@ -127,6 +138,11 @@ public class DataInitializerTest {
         this.dataSourceResults = new ArrayList<>();
         dataSourceResults.add(buildDataSourceResult(1.0, 1578307488));
         dataSourceResults.add(buildDataSourceResult(3.0, 1578307489));
+        this.detectorMapping = new DetectorMapping()
+                .setDetector(new com.expedia.adaptivealerting.anomdetect.mapper.Detector(
+                        UUID.fromString("2c49ba26-1a7d-43f4-b70c-c6644a2c1689")))
+                .setEnabled(false)
+                .setExpression(getExpression());
         when(dataSource.getMetricData(anyLong(), anyLong(), anyInt(), anyString())).thenReturn(dataSourceResults);
         initSeasonalNaiveDetector();
     }
@@ -150,5 +166,21 @@ public class DataInitializerTest {
         dataSourceResult.setDataPoint(value);
         dataSourceResult.setEpochSecond(epochSecs);
         return dataSourceResult;
+    }
+
+    private ExpressionTree getExpression() {
+        ExpressionTree expression = new ExpressionTree();
+        expression.setOperator(Operator.AND);
+        List<Operand> operands = new ArrayList<>();
+        val testOperand = new Operand();
+        testOperand.setField(new Field("name", "sample-app"));
+
+        val testOperand1 = new Operand();
+        testOperand1.setField(new Field("region", "us-west-2"));
+
+        operands.add(testOperand);
+        operands.add(testOperand1);
+        expression.setOperands(operands);
+        return expression;
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/source/data/initializer/DataInitializerTest.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.expedia.adaptivealerting.anomdetect.detect.AnomalyType.TWO_TAILED;
-import static com.sun.tools.classfile.AccessFlags.Kind.Field;
 import static java.util.UUID.randomUUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtilTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtilTest.java
@@ -92,7 +92,7 @@ public final class MetricUtilTest {
         val metricDefinition = new MetricDefinition(new TagCollection(tags));
         val metricData = new MetricData(metricDefinition, 100.0, Instant.now().getEpochSecond());
         val mappedMetricData = new MappedMetricData(metricData, mappedUuid);
-        val value = MetricUtil.getDataRetrievalValueOrTagsList(mappedMetricData, "function", "tags");
+        val value = MetricUtil.getDataRetrievalValue(mappedMetricData, "function");
         assertEquals("sum(test.metrics)", value);
     }
 }

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtilTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/util/MetricUtilTest.java
@@ -92,17 +92,7 @@ public final class MetricUtilTest {
         val metricDefinition = new MetricDefinition(new TagCollection(tags));
         val metricData = new MetricData(metricDefinition, 100.0, Instant.now().getEpochSecond());
         val mappedMetricData = new MappedMetricData(metricData, mappedUuid);
-        val value = MetricUtil.getDataRetrievalValueOrMetricKey(mappedMetricData, "function");
+        val value = MetricUtil.getDataRetrievalValueOrTagsList(mappedMetricData, "function", "tags");
         assertEquals("sum(test.metrics)", value);
-    }
-
-    @Test
-    public void testGetDataRetrievalValueOrMetricKey_getKey() {
-        val mappedUuid = UUID.randomUUID();
-        val metricDefinition = new MetricDefinition("metric-definition");
-        val metricData = new MetricData(metricDefinition, 100.0, Instant.now().getEpochSecond());
-        val mappedMetricData = new MappedMetricData(metricData, mappedUuid);
-        val value = MetricUtil.getDataRetrievalValueOrMetricKey(mappedMetricData, "");
-        assertEquals("metric-definition", value);
     }
 }


### PR DESCRIPTION
Use tags mentioned in detector mappings to query graphite when function tag is not available as part of the incoming metric. This is required for ELB 2xx metrics as it doesn't need to go via an aggregator.
`Use seriesByTag('tags') in case function tag is not there. Else use the function tag value to query graphite.`