### PR TITLE
Added spring data elastic search dependency and introduced new field …

### DIFF
--- a/modelservice/pom.xml
+++ b/modelservice/pom.xml
@@ -34,14 +34,15 @@
     <description>Adaptive Alerting Model Service.</description>
 
     <properties>
-        <codahale.metrics.version>3.0.2</codahale.metrics.version>
-        <jacoco-percentage>0.17</jacoco-percentage>
-        <jacoco-branch-percentage>0.25</jacoco-branch-percentage>
-        <percolator-client.version>6.7.1</percolator-client.version>
         <aws.sdk.version>1.11.126</aws.sdk.version>
         <aws-signing-request.version>0.0.22</aws-signing-request.version>
+        <codahale.metrics.version>3.0.2</codahale.metrics.version>
         <gson.version>2.8.2</gson.version>
+        <jacoco-percentage>0.17</jacoco-percentage>
+        <jacoco-branch-percentage>0.25</jacoco-branch-percentage>
         <jaxb-api.version>2.3.1</jaxb-api.version>
+        <percolator-client.version>6.7.1</percolator-client.version>
+        <spring-data-elasticsearch.version>3.2.7.RELEASE</spring-data-elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -142,6 +143,11 @@
         </dependency>
 
         <!-- elastic search -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-elasticsearch</artifactId>
+            <version>${spring-data-elasticsearch.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/acutator/CustomActuatorMetricServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/acutator/CustomActuatorMetricServiceImpl.java
@@ -50,7 +50,6 @@ public class CustomActuatorMetricServiceImpl implements CustomActuatorMetricServ
     public void increaseCount(final int status) {
         String counterName = "counter.status." + status;
         registry.counter(counterName).increment(1);
-        System.out.println("increasing");
         if (!statusList.contains(counterName)) {
             statusList.add(counterName);
         }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/acutator/CustomActuatorMetricServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/acutator/CustomActuatorMetricServiceImpl.java
@@ -50,6 +50,7 @@ public class CustomActuatorMetricServiceImpl implements CustomActuatorMetricServ
     public void increaseCount(final int status) {
         String counterName = "counter.status." + status;
         registry.counter(counterName).increment(1);
+        System.out.println("increasing");
         if (!statusList.contains(counterName)) {
             statusList.add(counterName);
         }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
@@ -15,6 +15,7 @@
  */
 package com.expedia.adaptivealerting.modelservice.elasticsearch;
 
+import com.expedia.adaptivealerting.modelservice.exception.MissingSystemPropertyException;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -47,11 +48,26 @@ public class ElasticSearchProperties {
 
     private Config config;
 
-    //TODO Update the config to use host and port instead of storing whole URL as a string
+    //TODO Update the elastic search config to use host and port instead of storing whole URL as a string
     @Data
     @Accessors(chain = true)
     public static class Url {
         private String host;
         private int port;
+    }
+
+    public static Url extractHostAndPortFromUrl(String urls) {
+        if (urls == null) {
+            throw new MissingSystemPropertyException("Elastic search URL not set in config");
+        }
+        String[] arrOfUrl = urls.split(":");
+        if (arrOfUrl.length <= 1) {
+            throw new MissingSystemPropertyException("Use host:port format to set URL in the config");
+        }
+
+        Url url = new Url();
+        url.setHost(arrOfUrl[0]);
+        url.setPort(Integer.parseInt(arrOfUrl[1]));
+        return url;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
@@ -15,20 +15,10 @@
  */
 package com.expedia.adaptivealerting.modelservice.elasticsearch;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.google.common.base.Supplier;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import lombok.val;
-import org.elasticsearch.client.RestClientBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-import vc.inreach.aws.request.AWSSigner;
-import vc.inreach.aws.request.AWSSigningRequestInterceptor;
-
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 @Data
 @Component
@@ -56,18 +46,11 @@ public class ElasticSearchProperties {
 
     private Config config;
 
-    public void addAWSRequestSignerInterceptor(RestClientBuilder clientBuilder) {
-        if (config.isAwsIamAuthRequired()) { // this is optional security for elastic search running in AWS
-            AWSSigningRequestInterceptor signingInterceptor = getAWSRequestSignerInterceptor();
-            clientBuilder.setHttpClientConfigCallback(
-                clientConf -> clientConf.addInterceptorLast(signingInterceptor));
-        }
-    }
-
-    private AWSSigningRequestInterceptor getAWSRequestSignerInterceptor() {
-        final Supplier<LocalDateTime> clock = () -> LocalDateTime.now(ZoneOffset.UTC);
-        AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-        val awsSigner = new AWSSigner(credentialsProvider, config.getAwsRegion(), "es", clock);
-        return new AWSSigningRequestInterceptor(awsSigner);
+    //TODO Update the config to use host and port instead of storing whole URL as a string
+    @Data
+    @Accessors(chain = true)
+    public static class Url {
+        private String host;
+        private int port;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
@@ -51,12 +51,12 @@ public class ElasticSearchProperties {
     //TODO Update the elastic search config to use host and port instead of storing whole URL as a string
     @Data
     @Accessors(chain = true)
-    public static class Url {
+    public static class HostAndPort {
         private String host;
         private int port;
     }
 
-    public static Url extractHostAndPortFromUrl(String urls) {
+    public static HostAndPort extractHostAndPortFromUrl(String urls) {
         if (urls == null) {
             throw new MissingSystemPropertyException("Elastic search URL not set in config");
         }
@@ -65,9 +65,9 @@ public class ElasticSearchProperties {
             throw new MissingSystemPropertyException("Use host:port format to set URL in the config");
         }
 
-        Url url = new Url();
-        url.setHost(arrOfUrl[0]);
-        url.setPort(Integer.parseInt(arrOfUrl[1]));
-        return url;
+        HostAndPort hostAndPort = new HostAndPort();
+        hostAndPort.setHost(arrOfUrl[0]);
+        hostAndPort.setPort(Integer.parseInt(arrOfUrl[1]));
+        return hostAndPort;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticSearchProperties.java
@@ -20,6 +20,7 @@ import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+//TODO Rename this to ElasticsearchProperties
 @Data
 @Component
 @ConfigurationProperties(prefix = "datasource-es")

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
@@ -42,25 +42,8 @@ public class ElasticsearchConfig {
 
     @Bean(destroyMethod = "close")
     public RestHighLevelClient client() {
-        ElasticSearchProperties.Url url = extractHostAndPortFromUrls();
+        ElasticSearchProperties.Url url = elasticSearchProperties.extractHostAndPortFromUrl(elasticSearchProperties.getUrls());
         RestHighLevelClient esClient = new RestHighLevelClient(RestClient.builder(new HttpHost(url.getHost(), url.getPort())));
         return esClient;
-    }
-
-    //TODO Update the config to use host and port instead of storing whole URL as a string
-    private ElasticSearchProperties.Url extractHostAndPortFromUrls() {
-        ElasticSearchProperties.Url url = new ElasticSearchProperties.Url();
-        String urls = elasticSearchProperties.getUrls();
-        if (urls == null) {
-            throw new MissingSystemPropertyException("Elastic search URL not set in config");
-        }
-        String[] arrOfUrl = urls.split(":");
-        if (arrOfUrl.length <= 1) {
-            throw new MissingSystemPropertyException("Use host:port format to set URL in the config");
-        }
-
-        url.setHost(arrOfUrl[0]);
-        url.setPort(Integer.parseInt(arrOfUrl[1]));
-        return url;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.elasticsearch;
+
+import com.expedia.adaptivealerting.modelservice.exception.MissingSystemPropertyException;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+/**
+ * Elastic search config used by spring data elastic search
+ */
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.expedia.adaptivealerting.modelservice.repo")
+public class ElasticsearchConfig {
+
+    @Autowired
+    private ElasticSearchProperties elasticSearchProperties;
+
+    @Bean
+    public ElasticsearchRestTemplate elasticsearchTemplate() {
+        return new ElasticsearchRestTemplate(client());
+    }
+
+    @Bean(destroyMethod = "close")
+    public RestHighLevelClient client() {
+        ElasticSearchProperties.Url url = extractHostAndPortFromUrls();
+        RestHighLevelClient esClient = new RestHighLevelClient(RestClient.builder(new HttpHost(url.getHost(), url.getPort())));
+        return esClient;
+    }
+
+    //TODO Update the config to use host and port instead of storing whole URL as a string
+    private ElasticSearchProperties.Url extractHostAndPortFromUrls() {
+        ElasticSearchProperties.Url url = new ElasticSearchProperties.Url();
+        String urls = elasticSearchProperties.getUrls();
+        if (urls == null) {
+            throw new MissingSystemPropertyException("Elastic search URL not set in config");
+        }
+        String[] arrOfUrl = urls.split(":");
+        if (arrOfUrl.length <= 1) {
+            throw new MissingSystemPropertyException("Use host:port format to set URL in the config");
+        }
+
+        url.setHost(arrOfUrl[0]);
+        url.setPort(Integer.parseInt(arrOfUrl[1]));
+        return url;
+    }
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
@@ -15,7 +15,6 @@
  */
 package com.expedia.adaptivealerting.modelservice.elasticsearch;
 
-import com.expedia.adaptivealerting.modelservice.exception.MissingSystemPropertyException;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfig.java
@@ -41,8 +41,8 @@ public class ElasticsearchConfig {
 
     @Bean(destroyMethod = "close")
     public RestHighLevelClient client() {
-        ElasticSearchProperties.Url url = elasticSearchProperties.extractHostAndPortFromUrl(elasticSearchProperties.getUrls());
-        RestHighLevelClient esClient = new RestHighLevelClient(RestClient.builder(new HttpHost(url.getHost(), url.getPort())));
+        ElasticSearchProperties.HostAndPort hostAndPort = elasticSearchProperties.extractHostAndPortFromUrl(elasticSearchProperties.getUrls());
+        RestHighLevelClient esClient = new RestHighLevelClient(RestClient.builder(new HttpHost(hostAndPort.getHost(), hostAndPort.getPort())));
         return esClient;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticSearchClient.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticSearchClient.java
@@ -46,6 +46,7 @@ import java.io.IOException;
  */
 @Component
 @Generated // (excluding from code coverage)
+@Deprecated
 public class LegacyElasticSearchClient {
 
     @Autowired

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticSearchClient.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticSearchClient.java
@@ -44,6 +44,7 @@ import java.io.IOException;
  * we can't easily mock methods of class {@code RestHighLevelClient}, which are final.
  * So this wrapper class will help to address the issue.
  */
+//TODO Rename this to ElasticsearchClient
 @Component
 @Generated // (excluding from code coverage)
 @Deprecated

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
@@ -37,6 +37,7 @@ public class LegacyElasticsearchConfig {
     }
 
     private RestClientBuilder buildRestClientBuilder() {
+        System.out.println(elasticSearchProperties.getUrls());
         return RestClient.builder(
                 HttpHost.create(
                         elasticSearchProperties.getUrls()))

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Deprecated
 public class LegacyElasticsearchConfig {
 
     @Autowired

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/elasticsearch/LegacyElasticsearchConfig.java
@@ -37,7 +37,6 @@ public class LegacyElasticsearchConfig {
     }
 
     private RestClientBuilder buildRestClientBuilder() {
-        System.out.println(elasticSearchProperties.getUrls());
         return RestClient.builder(
                 HttpHost.create(
                         elasticSearchProperties.getUrls()))

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Detector entity
+ */
+@Data
+@Accessors(chain = true)
+@Document(indexName = "detectors_new", type = "detector")
+//This automatically creates an index if it doesn't exist
+public class Detector {
+
+    @Id
+    public String id;
+
+    @Field(type = FieldType.Text)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private UUID uuid;
+
+    @NotNull
+    @Field(type = FieldType.Text)
+    private String type;
+
+    @Field(type = FieldType.Boolean)
+    private boolean enabled;
+
+    @Field(type = FieldType.Boolean)
+    private boolean trusted;
+
+    @Field(type = FieldType.Object)
+    private Map<String, Object> detectorConfig;
+
+    @Field(type = FieldType.Object)
+    private Meta meta;
+
+    @Data
+    public static class Meta {
+
+        @Field(type = FieldType.Text)
+        private String createdBy;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date dateLastAccessed;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date dateLastUpdated;
+    }
+
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/exception/MissingSystemPropertyException.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/exception/MissingSystemPropertyException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.exception;
+
+public class MissingSystemPropertyException extends IllegalStateException {
+    public MissingSystemPropertyException(final String message) {
+        super(message);
+    }
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.repo;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface DetectorRepository extends ElasticsearchRepository<Detector, String> {
+
+    Detector save(Detector detector);
+
+    Detector findByUuid(String uuid);
+
+    Iterable<Detector> findAll();
+
+    List<Detector> findByMeta_CreatedBy(String user);
+
+    List<Detector> findByMeta_DateLastUpdatedGreaterThan(String date);
+
+    List<Detector> findByMeta_DateLastAccessedLessThan(String date);
+
+    void deleteByUuid(String uuid);
+
+    boolean existsById(String primaryKey);
+
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/LegacyDetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/LegacyDetectorRepository.java
@@ -20,6 +20,7 @@ import com.expedia.adaptivealerting.anomdetect.source.DetectorDocument;
 import java.util.List;
 import java.util.UUID;
 
+@Deprecated
 public interface LegacyDetectorRepository {
 
     /**

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/LegacyDetectorRepositoryImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/impl/LegacyDetectorRepositoryImpl.java
@@ -57,6 +57,7 @@ import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 
 @Slf4j
 @Service
+@Deprecated
 public class LegacyDetectorRepositoryImpl implements LegacyDetectorRepository {
     private static final String DETECTOR_INDEX = "detectors";
     private static final String DETECTOR_DOC_TYPE = "detector";

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.service;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface DetectorService {
+
+    /**
+     * Saves a detector to the detector store. The detector UUID must be {@literal null}, as this method
+     * assigns a UUID.
+     *
+     * @param detector Detector
+     * @return Detector UUID assigned by this call
+     */
+    UUID createDetector(Detector detector);
+
+    Detector findByUuid(String uuid);
+
+    List<Detector> findByCreatedBy(String user);
+
+    void toggleDetector(String uuid, Boolean enabled);
+
+    void trustDetector(String uuid, Boolean trusted);
+
+    List<Detector> getLastUpdatedDetectors(long interval);
+
+    List<Detector> getLastUsedDetectors(int noOfDays);
+
+    void updateDetector(String uuid, Detector detector);
+
+    void updateDetectorLastUsed(String uuid);
+
+    void deleteDetector(String uuid);
+
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.service;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
+import com.expedia.adaptivealerting.modelservice.repo.DetectorRepository;
+import com.expedia.adaptivealerting.modelservice.util.DateUtil;
+import com.expedia.adaptivealerting.modelservice.util.RequestValidator;
+import lombok.val;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.isNull;
+import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
+
+@Service
+public class DetectorServiceImpl implements DetectorService {
+
+    @Autowired
+    private DetectorRepository repository;
+
+    @Override
+    public UUID createDetector(Detector detector) {
+        notNull(detector, "detectorDto can't be null");
+        isNull(detector.getUuid(), "Required: detectorDto.uuid == null");
+
+        val uuid = UUID.randomUUID();
+        detector.setId(uuid.toString());
+        detector.setUuid(uuid);
+        detector.setMeta(buildDetectorMetaData(detector));
+        RequestValidator.validateDetector(detector);
+        repository.save(detector);
+        return uuid;
+    }
+
+    @Override
+    public Detector findByUuid(String uuid) {
+        Detector detector = repository.findByUuid(uuid);
+        if (detector == null) {
+            throw new RecordNotFoundException("Invalid UUID: " + uuid);
+        }
+        return detector;
+    }
+
+    @Override
+    public List<Detector> findByCreatedBy(String user) {
+        List<Detector> detectors = repository.findByMeta_CreatedBy(user);
+        if (detectors == null || detectors.isEmpty()) {
+            throw new RecordNotFoundException("Invalid user: " + user);
+        }
+        return detectors;
+    }
+
+    @Override
+    public void toggleDetector(String uuid, Boolean enabled) {
+        Detector detector = repository.findByUuid(uuid);
+        detector.setEnabled(enabled);
+        repository.save(detector);
+    }
+
+    @Override
+    public void trustDetector(String uuid, Boolean trusted) {
+        Detector detector = repository.findByUuid(uuid);
+        detector.setTrusted(trusted);
+        repository.save(detector);
+    }
+
+    @Override
+    public List<Detector> getLastUpdatedDetectors(long interval) {
+        val now = DateUtil.now().toInstant();
+        val fromDate = DateUtil.toUtcDateString((now.minus(interval, ChronoUnit.SECONDS)));
+        return repository.findByMeta_DateLastUpdatedGreaterThan(fromDate);
+    }
+
+    @Override
+    public List<Detector> getLastUsedDetectors(int noOfDays) {
+        val now = DateUtil.now().toInstant();
+        val fromDate = DateUtil.toUtcDateString((now.minus(noOfDays, ChronoUnit.DAYS)));
+        return repository.findByMeta_DateLastAccessedLessThan(fromDate);
+    }
+
+    @Override
+    public void updateDetector(String uuid, Detector detector) {
+        notNull(detector, "detector can't be null");
+        MDC.put("DetectorUuid", uuid);
+
+        Detector detectorToBeUpdated = repository.findByUuid(uuid);
+        detectorToBeUpdated.setDetectorConfig(detector.getDetectorConfig());
+        detectorToBeUpdated.setMeta(buildDetectorMetaData(detector));
+        RequestValidator.validateDetector(detectorToBeUpdated);
+        repository.save(detectorToBeUpdated);
+    }
+
+    @Override
+    public void updateDetectorLastUsed(String uuid) {
+        notNull(uuid, "uuid can't be null");
+        MDC.put("DetectorUuid", uuid);
+
+        Detector detectorToBeUpdated = repository.findByUuid(uuid);
+        detectorToBeUpdated.setMeta(buildDetectorMetaData(detectorToBeUpdated));
+        RequestValidator.validateDetector(detectorToBeUpdated);
+        repository.save(detectorToBeUpdated);
+    }
+
+    @Override
+    public void deleteDetector(String uuid) {
+        repository.deleteByUuid(uuid);
+    }
+
+    private Detector.Meta buildDetectorMetaData(Detector detector) {
+        Date nowDate = DateUtil.now();
+        Detector.Meta metaBlock = detector.getMeta();
+        metaBlock = (metaBlock == null) ? new Detector.Meta() : detector.getMeta();
+        metaBlock.setDateLastUpdated(nowDate);
+        metaBlock.setDateLastAccessed(nowDate);
+        return metaBlock;
+    }
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/RequestValidator.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/RequestValidator.java
@@ -23,6 +23,7 @@ import com.expedia.adaptivealerting.modelservice.domain.mapping.Operand;
 import com.expedia.adaptivealerting.modelservice.domain.mapping.Operator;
 import com.expedia.adaptivealerting.modelservice.domain.mapping.User;
 import com.expedia.adaptivealerting.modelservice.domain.percolator.PercolatorDetectorMapping;
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
 import lombok.experimental.UtilityClass;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -67,5 +68,13 @@ public class RequestValidator {
 
     public static void validateDetectorDocument(DetectorDocument document) {
         new DetectorFactory().buildDetector(document);
+    }
+
+    public static void validateDetector(Detector detector) {
+        DetectorDocument detectorDocument = new DetectorDocument()
+                .setUuid(detector.getUuid())
+                .setConfig(detector.getDetectorConfig())
+                .setType(detector.getType());
+        validateDetectorDocument(detectorDocument);
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -67,7 +67,6 @@ public class DetectorController {
     public List<Detector> findByCreatedBy(@RequestParam String user) {
         List<Detector> detectors = service.findByCreatedBy(user);
         if (detectors == null || detectors.isEmpty()) {
-            // TODO: This should be RecordNotFoundException
             throw new RecordNotFoundException("Invalid user: " + user);
         }
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -95,7 +95,7 @@ public class DetectorController {
         return service.getLastUpdatedDetectors(intervalInSeconds);
     }
 
-    @GetMapping(path = "/getDetectorLastUsed", produces = "application/json")
+    @GetMapping(path = "/getLastUsedDetectors", produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
     public List<Detector> getLastUsedDetectors(@RequestParam int noOfDays) {
         return service.getLastUsedDetectors(noOfDays);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.web;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
+import com.expedia.adaptivealerting.modelservice.service.DetectorService;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "/api/v3/detectors")
+@Slf4j
+public class DetectorController {
+
+    @Autowired
+    private DetectorService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public String createDetector(@Valid @RequestBody Detector detector) {
+        val uuid = service.createDetector(detector);
+        return uuid.toString();
+    }
+
+    @GetMapping(path = "/findByUuid", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public Detector findByUuid(@RequestParam String uuid) {
+        Detector detector = service.findByUuid(uuid);
+        if (detector == null) {
+            throw new RecordNotFoundException("Invalid UUID: " + uuid);
+        }
+        return detector;
+    }
+
+    @GetMapping(path = "/findByCreatedBy", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Detector> findByCreatedBy(@RequestParam String user) {
+        List<Detector> detectors = service.findByCreatedBy(user);
+        if (detectors == null || detectors.isEmpty()) {
+            // TODO: This should be RecordNotFoundException
+            throw new RecordNotFoundException("Invalid user: " + user);
+        }
+
+        return detectors;
+    }
+
+    @PostMapping(path = "/toggleDetector")
+    @ResponseStatus(HttpStatus.OK)
+    public void toggleDetector(@RequestParam String uuid, @RequestParam Boolean enabled) {
+        Assert.notNull(uuid, "uuid can't be null");
+        Assert.notNull(enabled, "enabled can't be null");
+        service.toggleDetector(uuid, enabled);
+    }
+
+    @PostMapping(path = "/trustDetector")
+    @ResponseStatus(HttpStatus.OK)
+    public void trustDetector(@RequestParam String uuid, @RequestParam Boolean trusted) {
+        Assert.notNull(uuid, "uuid can't be null");
+        Assert.notNull(trusted, "trusted can't be null");
+        service.trustDetector(uuid, trusted);
+    }
+
+    @GetMapping(path = "/getLastUpdatedDetectors", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Detector> getLastUpdatedDetectors(@RequestParam long intervalInSeconds) {
+        return service.getLastUpdatedDetectors(intervalInSeconds);
+    }
+
+    @GetMapping(path = "/getDetectorLastUsed", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Detector> getLastUsedDetectors(@RequestParam int noOfDays) {
+        return service.getLastUsedDetectors(noOfDays);
+    }
+
+    @PutMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void updateDetector(@RequestParam String uuid, @RequestBody Detector detector) {
+        service.updateDetector(uuid, detector);
+    }
+
+    @PutMapping(path = "/updateDetectorLastUsed", consumes = "application/json", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public void updatedDetectorLastUsed(@RequestBody Map<String, String> params) {
+        service.updateDetectorLastUsed(params.get("uuid"));
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteDetector(@RequestParam String uuid) {
+        service.deleteDetector(uuid);
+    }
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/LegacyDetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/LegacyDetectorController.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping(path = "/api/v2/detectors")
+@Deprecated
 public class LegacyDetectorController {
 
     @Autowired

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/SwaggerConfiguration.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/SwaggerConfiguration.java
@@ -82,6 +82,7 @@ public class SwaggerConfiguration {
                 // regex("/additional_endpoints/.*?"),
                 regex("/api/detectorMappings.*?"),
                 regex("/api/v2/detectors.*?"),
+                regex("/api/v3/detectors.*?"),
                 regex("/api/metricProfiling.*?"),
                 regex("/api/anomalies.*?")
         );

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfigTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/elasticsearch/ElasticsearchConfigTest.java
@@ -1,0 +1,48 @@
+package com.expedia.adaptivealerting.modelservice.elasticsearch;
+
+import com.expedia.adaptivealerting.modelservice.exception.MissingSystemPropertyException;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class ElasticsearchConfigTest {
+
+    @InjectMocks
+    private ElasticsearchConfig elasticSearchConfig;
+
+    @Mock
+    private ElasticSearchProperties elasticSearchProperties;
+
+    @Before
+    public void setUp() {
+        this.elasticSearchConfig = new ElasticsearchConfig();
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testRestTemplate() {
+        when(elasticSearchProperties.getUrls()).thenReturn("localhost:8000");
+        val elasticsearchRestTemplate = elasticSearchConfig.elasticsearchTemplate();
+        assertNotNull(elasticsearchRestTemplate);
+    }
+
+    @Test(expected = MissingSystemPropertyException.class)
+    public void testRestTemplate_invalid_config() {
+        when(elasticSearchProperties.getUrls()).thenReturn(null);
+        val restHighLevelClient = elasticSearchConfig.client();
+        assertNotNull(restHighLevelClient);
+    }
+
+    @Test(expected = MissingSystemPropertyException.class)
+    public void testRestTemplate_invalid_config1() {
+        when(elasticSearchProperties.getUrls()).thenReturn("localhost");
+        val restHighLevelClient = elasticSearchConfig.client();
+        assertNotNull(restHighLevelClient);
+    }
+}

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -1,0 +1,156 @@
+package com.expedia.adaptivealerting.modelservice.service.impl;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
+import com.expedia.adaptivealerting.modelservice.repo.DetectorRepository;
+import com.expedia.adaptivealerting.modelservice.service.DetectorService;
+import com.expedia.adaptivealerting.modelservice.service.DetectorServiceImpl;
+import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DetectorServiceImplTest {
+
+    @InjectMocks
+    private DetectorService serviceUnderTest;
+
+    @Mock
+    private DetectorRepository repository;
+
+    @Mock
+    private List<Detector> detectors;
+
+    private UUID someUuid;
+
+    private Detector legalParamsDetector;
+
+    @Before
+    public void setUp() {
+        this.serviceUnderTest = new DetectorServiceImpl();
+        MockitoAnnotations.initMocks(this);
+        initTestObjects();
+        initDependencies();
+    }
+
+    @Test
+    public void testCreateDetector() {
+        legalParamsDetector.setUuid(null);
+        val uuid = serviceUnderTest.createDetector(legalParamsDetector);
+        assertNotNull(uuid);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDetector_null_detector() {
+        serviceUnderTest.createDetector(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDetector_set_uuid() {
+        legalParamsDetector.setUuid(UUID.randomUUID());
+        serviceUnderTest.createDetector(legalParamsDetector);
+    }
+
+    @Test
+    public void testFindByUuid() {
+        val actualDetector = serviceUnderTest.findByUuid(someUuid.toString());
+        assertNotNull(actualDetector);
+    }
+
+
+    @Test(expected = RecordNotFoundException.class)
+    public void testFindByUuid_invalid_uuid() {
+        val actualDetector = serviceUnderTest.findByUuid(UUID.randomUUID().toString());
+        assertNotNull(actualDetector);
+    }
+
+    @Test
+    public void testFindByCreatedBy() {
+        val actualDetectors = serviceUnderTest.findByCreatedBy("userName");
+        assertNotNull(actualDetectors);
+    }
+
+    @Test(expected = RecordNotFoundException.class)
+    public void testFindByCreatedBy_invalid_user() {
+        val actualDetectors = serviceUnderTest.findByCreatedBy("invalidUserName");
+        assertNotNull(actualDetectors);
+    }
+
+    @Test
+    public void testToggleDetector() {
+        serviceUnderTest.toggleDetector(someUuid.toString(), true);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testTrustDetector() {
+        serviceUnderTest.trustDetector(someUuid.toString(), true);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testGetLastUpdatedDetectors() {
+        val actualDetectors = serviceUnderTest.getLastUpdatedDetectors(5);
+        assertNotNull(actualDetectors);
+        assertSame(detectors, actualDetectors);
+    }
+
+    @Test
+    public void testGetLastUsedDetectors() {
+        val actualDetectors = serviceUnderTest.getLastUsedDetectors(4);
+        assertNotNull(actualDetectors);
+        assertSame(detectors, actualDetectors);
+    }
+
+    @Test
+    public void testUpdateDetector() {
+        serviceUnderTest.updateDetector(someUuid.toString(), legalParamsDetector);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testUpdateDetectorLastUsed() {
+        serviceUnderTest.updateDetectorLastUsed(someUuid.toString());
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testDeleteDetector() {
+        val someUuidStr = someUuid.toString();
+        serviceUnderTest.deleteDetector(someUuidStr);
+        verify(repository, times(1)).deleteByUuid(someUuidStr);
+    }
+
+    private void initTestObjects() {
+        this.someUuid = UUID.randomUUID();
+        val mom = ObjectMother.instance();
+        this.legalParamsDetector = mom.buildDetector();
+        legalParamsDetector.setUuid(someUuid);
+    }
+
+    private void initDependencies() {
+        when(repository.save(any(Detector.class))).thenReturn(legalParamsDetector);
+        when(repository.findByUuid(someUuid.toString())).thenReturn(legalParamsDetector);
+        when(repository.findByMeta_CreatedBy("userName")).thenReturn(detectors);
+        when(repository.findByMeta_DateLastUpdatedGreaterThan(anyString())).thenReturn(detectors);
+        when(repository.findByMeta_DateLastAccessedLessThan(anyString())).thenReturn(detectors);
+    }
+}

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
@@ -17,6 +17,7 @@ package com.expedia.adaptivealerting.modelservice.test;
 
 import com.expedia.adaptivealerting.anomdetect.source.DetectorDocument;
 import com.expedia.adaptivealerting.modelservice.domain.mapping.*;
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
 import com.expedia.adaptivealerting.modelservice.web.request.AnomalyRequest;
 import com.expedia.adaptivealerting.modelservice.metricsource.MetricSourceResult;
 import com.expedia.adaptivealerting.modelservice.util.DateUtil;
@@ -67,6 +68,17 @@ public class ObjectMother {
         detector.setType("constant-detector");
         detector.setConfig(buildDetectorConfig());
         return detector;
+    }
+
+    /**
+     * Returns a detector entity with the UUID set to {@literal null}.
+     *
+     * @return Detector with the UUID set to {@literal null}.
+     */
+    public Detector buildDetector() {
+        return new Detector()
+                .setType("constant-detector")
+                .setDetectorConfig(buildDetectorConfig());
     }
 
     public DetectorDocument getIllegalParamsDetector() {

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.web;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
+import com.expedia.adaptivealerting.modelservice.service.DetectorService;
+import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest
+public class DetectorControllerTest {
+
+    @Spy
+    @InjectMocks
+    private DetectorController controllerUnderTest;
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private DetectorService detectorService;
+
+    @Mock
+    private Detector detector;
+
+    @Mock
+    private List<Detector> detectors;
+
+    private UUID someUuid;
+    private Detector legalParamsDetector;
+
+    @Before
+    public void setUp() {
+        this.controllerUnderTest = new DetectorController();
+        mockMvc = MockMvcBuilders.standaloneSetup(controllerUnderTest).setHandlerExceptionResolvers(new ExceptionHandlerExceptionResolver()).build();
+
+        MockitoAnnotations.initMocks(this);
+        initTestObjects();
+        initDependencies();
+    }
+
+    @Test
+    public void testCreateDetector() {
+        val uuidStr = controllerUnderTest.createDetector(legalParamsDetector);
+        val uuid = UUID.fromString(uuidStr);
+        assertNotNull(uuid);
+    }
+
+    @Test
+    public void testFindByUuid() {
+        val actualDetector = controllerUnderTest.findByUuid(someUuid.toString());
+        assertNotNull(actualDetector);
+    }
+
+    @Test(expected = RecordNotFoundException.class)
+    public void testFindByUuid_record_not_found_null_response() {
+        when(detectorService.findByUuid(anyString())).thenReturn(null);
+        controllerUnderTest.findByUuid(someUuid.toString());
+    }
+
+    @Test
+    public void testFindByCreatedBy() {
+        when(detectorService.findByCreatedBy(anyString())).thenReturn(detectors);
+        val actualDetectors = controllerUnderTest.findByCreatedBy("kashah");
+        assertNotNull(actualDetectors);
+    }
+
+    @Test(expected = RecordNotFoundException.class)
+    public void test_FindByCreatedBy_illegal_args() {
+        when(detectorService.findByCreatedBy(anyString())).thenReturn(null);
+        controllerUnderTest.findByCreatedBy("kashah");
+    }
+
+    @Test(expected = RecordNotFoundException.class)
+    public void testFindByCreatedBy_illegal_args1() {
+        when(detectorService.findByCreatedBy(anyString())).thenReturn(new ArrayList<>());
+        controllerUnderTest.findByCreatedBy("kashah");
+    }
+
+    @Test
+    public void testUrlsWithoutFullPath_fail() throws Exception {
+        mockMvc.perform(get("/findByUuid").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
+        mockMvc.perform(get("/findByCreatedBy").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void testToggleDetector() {
+        controllerUnderTest.toggleDetector(someUuid.toString(), true);
+        verify(detectorService, times(1)).toggleDetector(someUuid.toString(), true);
+    }
+
+    @Test
+    public void testTrustDetector() {
+        controllerUnderTest.trustDetector(someUuid.toString(), true);
+        verify(detectorService, times(1)).trustDetector(someUuid.toString(), true);
+    }
+
+    @Test
+    public void testGetLastUpdatedDetectors() {
+        val actualDetectors = controllerUnderTest.getLastUpdatedDetectors(5);
+        assertNotNull(actualDetectors);
+        assertSame(detectors, actualDetectors);
+    }
+
+    @Test
+    public void testGetLastUsedDetectors() {
+        val actualDetectors = controllerUnderTest.getLastUsedDetectors(5);
+        assertNotNull(actualDetectors);
+        assertSame(detectors, actualDetectors);
+    }
+
+    @Test
+    public void testUpdateDetector() {
+        controllerUnderTest.updateDetector(someUuid.toString(), legalParamsDetector);
+        verify(detectorService, times(1)).updateDetector(someUuid.toString(), legalParamsDetector);
+    }
+
+    @Test
+    public void testUpdatedDetectorLastUsed() {
+        Map<String, String> requestBody = Collections.singletonMap("uuid", someUuid.toString());
+        controllerUnderTest.updatedDetectorLastUsed(requestBody);
+        verify(detectorService, times(1)).updateDetectorLastUsed(someUuid.toString());
+    }
+
+    @Test
+    public void testDeleteDetector() {
+        val someUuidStr = someUuid.toString();
+        controllerUnderTest.deleteDetector(someUuidStr);
+        verify(detectorService, times(1)).deleteDetector(someUuidStr);
+    }
+
+    private void initTestObjects() {
+        this.someUuid = UUID.randomUUID();
+        val mom = ObjectMother.instance();
+        this.legalParamsDetector = mom.buildDetector();
+        legalParamsDetector.setUuid(someUuid);
+    }
+
+    private void initDependencies() {
+        when(detectorService.createDetector(any(Detector.class))).thenReturn(someUuid);
+        when(detectorService.findByUuid(someUuid.toString())).thenReturn(detector);
+        when(detectorService.getLastUpdatedDetectors(anyLong())).thenReturn(detectors);
+        when(detectorService.getLastUsedDetectors(anyInt())).thenReturn(detectors);
+    }
+}


### PR DESCRIPTION
- Introduced spring data elastic search dependency in model service. Currently, it doesn't support percolator field type (It is mentioned that it will be available in upcoming releases) so for now, we will have to live with two elastic search configurations, one that invokes spring-data-elastic search rest-client (Detector index uses this client) and another one directly invokes elastic search rest-client (Detector mapping index uses this client since it has a percolator dependency)

- Added a new field `dateLastAccessed` as part of Meta in the detector and also `createdBy`, `dateLastUpdated` fields have been moved to Meta now. We weren't using `dateCreated` field so that has been removed.

```
public class Detector {

    @Field(type = FieldType.Object)
    private Meta meta;

    @Data
    public static class Meta {

        @Field(type = FieldType.Text)
        private String createdBy;

        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
        private Date dateLastAccessed;

        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
        private Date dateLastUpdated;
    }
```

- Exposed new endpoints `/getLastUsedDetectors` & ` /updateDetectorLastUsed` to keep a track of detector usage

- This is a non-breaking change. `/api/v2/detectors` still exists and once we are sure everything is working fine, the old detector index will be copied to the new detector index and all the legacy endpoints and classes will be removed.