### PR TITLE
Upgraded elastic search version in docker compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   # Dependencies
   elasticsearch:
-    image: elasticsearch:6.5.0
+    image: elasticsearch:6.7.2
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       xpack.security.enabled: "false"


### PR DESCRIPTION
Upgraded elastic search version in docker compose from 6.5 to 6.7