### PR TITLE
Use LinkedHashSet instead of HashSet to maintain the order

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -37,8 +37,8 @@ import org.slf4j.MDC;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,7 +108,7 @@ public class DetectorManager {
         this.dataInitializer = dataInitializer;
         this.detectorSource = detectorSource;
         this.detectorRefreshTimePeriod = config.getInt(CK_DETECTOR_REFRESH_PERIOD);
-        this.detectorsLastUsedTimeToBeUpdatedSet = new HashSet<>();
+        this.detectorsLastUsedTimeToBeUpdatedSet = new LinkedHashSet<>();
 
         this.metricRegistry = metricRegistry;
         detectorForTimer = metricRegistry.timer("detector.detectorFor");

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/DetectorManagerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/DetectorManagerTest.java
@@ -140,7 +140,7 @@ public final class DetectorManagerTest {
 
     @Test
     public void testDetectorLastUsedTimeSync_unique_detectors() {
-        int setSize = 15000;
+        int setSize = 50;
         populateSetWithUniqueUUIDs(setSize);
         managerUnderTest.detectorLastUsedTimeSync(System.currentTimeMillis() + 1000 * 60);
         verify(detectorSource, atMost(setSize)).updatedDetectorLastUsed(any(UUID.class));

--- a/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/DetectorManagerTest.java
+++ b/anomdetect/src/test/java/com/expedia/adaptivealerting/anomdetect/DetectorManagerTest.java
@@ -140,7 +140,7 @@ public final class DetectorManagerTest {
 
     @Test
     public void testDetectorLastUsedTimeSync_unique_detectors() {
-        int setSize = 4;
+        int setSize = 15000;
         populateSetWithUniqueUUIDs(setSize);
         managerUnderTest.detectorLastUsedTimeSync(System.currentTimeMillis() + 1000 * 60);
         verify(detectorSource, atMost(setSize)).updatedDetectorLastUsed(any(UUID.class));


### PR DESCRIPTION
Use LinkedHashSet for detectorsLastUsedTimeToBeUpdatedSet instead of HashSet to maintain the order in which UUIDs are added