### PR TITLE
Bug fix/concurrent modification exception

### DIFF
--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -290,11 +290,8 @@ public class DetectorManager {
     }
 
     private void processDetectorsLastUsedTimeSet() {
-
+        
         Set<UUID> detectorsLastUsedTimeSetClone = buildDetectorLastUsedSetClone();
-
-        log.info("Updating last used time for a total of {} invoked detectors", detectorsLastUsedTimeSetClone.size());
-
         int counter = 0;
         for (Iterator<UUID> iterator = detectorsLastUsedTimeSetClone.iterator(); iterator.hasNext(); ) {
             UUID detectorUuid = iterator.next();
@@ -306,7 +303,6 @@ public class DetectorManager {
             }
             iterator.remove();
         }
-
         log.info("Updated last used time for a total of {} invoked detectors", counter);
     }
 
@@ -318,6 +314,8 @@ public class DetectorManager {
             detectorsLastUsedTimeSetClone.add(detectorUuid);
         }
         detectorsLastUsedTimeToBeUpdatedSet.removeAll(detectorsLastUsedTimeSetClone);
+
+        log.info("Updating last used time for a total of {} invoked detectors", detectorsLastUsedTimeSetClone.size());
         return detectorsLastUsedTimeSetClone;
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -39,7 +39,6 @@ import org.slf4j.MDC;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -313,6 +313,6 @@ public class DetectorManager {
                 }
             }
         }
-        log.info("Updated last used time for a total of {} invoked detectors", counter);
+        log.info("Updated last used time of {} detectors out of {} invoked detectors ", counter, detectorsLastUsedTimeToBeUpdatedSet.size());
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -46,13 +46,11 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.notNull;
 

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -300,19 +300,19 @@ public class DetectorManager {
 
     private void processDetectorLastUsedQueue(int detectorsLastUsedTimeQueueSize) {
         Set<UUID> detectorsLastUsedTimeToBeUpdatedSet = new HashSet<>();
-        int counter = 0;
+        int noOfDetectorsUpdated = 0;
         for (int i = 0; i < detectorsLastUsedTimeQueueSize; i++) {
             UUID detectorUUID = detectorsLastUsedTimeToBeUpdatedQueue.poll();
             if (!detectorsLastUsedTimeToBeUpdatedSet.contains(detectorUUID)) {
                 detectorsLastUsedTimeToBeUpdatedSet.add(detectorUUID);
                 try {
                     detectorSource.updatedDetectorLastUsed(detectorUUID);
-                    counter++;
+                    noOfDetectorsUpdated++;
                 } catch (DetectorException ex) {
                     log.error("Error updating last accessed time for detector UUID: {}", detectorUUID);
                 }
             }
         }
-        log.info("Updated last used time of {} detectors out of {} invoked detectors ", counter, detectorsLastUsedTimeToBeUpdatedSet.size());
+        log.info("Updated last used time of {} detectors out of {} invoked detectors ", noOfDetectorsUpdated, detectorsLastUsedTimeToBeUpdatedSet.size());
     }
 }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -295,32 +295,23 @@ public class DetectorManager {
         int detectorsLastUsedTimeQueueSize = detectorsLastUsedTimeToBeUpdatedQueue.size();
         log.info("Detectors last used time queue size {}", detectorsLastUsedTimeQueueSize);
 
-        Set<UUID> detectorsLastUsedTimeToBeUpdatedSet = buildDetectorsLastTimeToBeUpdatedSet(detectorsLastUsedTimeQueueSize);
-        log.info("Updating last used time for a total of {} invoked detectors", detectorsLastUsedTimeToBeUpdatedSet.size());
-
-        processDetectorLastUsedSet(detectorsLastUsedTimeToBeUpdatedSet);
+        processDetectorLastUsedQueue(detectorsLastUsedTimeQueueSize);
     }
 
-    private Set<UUID> buildDetectorsLastTimeToBeUpdatedSet(int detectorsLastUsedTimeQueueSize) {
+    private void processDetectorLastUsedQueue(int detectorsLastUsedTimeQueueSize) {
         Set<UUID> detectorsLastUsedTimeToBeUpdatedSet = new HashSet<>();
+        int counter = 0;
         for (int i = 0; i < detectorsLastUsedTimeQueueSize; i++) {
             UUID detectorUUID = detectorsLastUsedTimeToBeUpdatedQueue.poll();
-            detectorsLastUsedTimeToBeUpdatedSet.add(detectorUUID);
-        }
-        return detectorsLastUsedTimeToBeUpdatedSet;
-    }
-
-    private void processDetectorLastUsedSet(Set<UUID> detectorsLastUsedTimeSet) {
-        int counter = 0;
-        for (Iterator<UUID> iterator = detectorsLastUsedTimeSet.iterator(); iterator.hasNext(); ) {
-            UUID detectorUuid = iterator.next();
-            try {
-                detectorSource.updatedDetectorLastUsed(detectorUuid);
-                counter++;
-            } catch (DetectorException ex) {
-                log.error("Error updating last accessed time for detector UUID: {}", detectorUuid);
+            if (!detectorsLastUsedTimeToBeUpdatedSet.contains(detectorUUID)) {
+                detectorsLastUsedTimeToBeUpdatedSet.add(detectorUUID);
+                try {
+                    detectorSource.updatedDetectorLastUsed(detectorUUID);
+                    counter++;
+                } catch (DetectorException ex) {
+                    log.error("Error updating last accessed time for detector UUID: {}", detectorUUID);
+                }
             }
-            iterator.remove();
         }
         log.info("Updated last used time for a total of {} invoked detectors", counter);
     }

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -310,9 +310,9 @@ public class DetectorManager {
         return detectorsLastUsedTimeToBeUpdatedSet;
     }
 
-    private void processDetectorLastUsedSet(Set<UUID> detectorsLastUsedTimeSetClone) {
+    private void processDetectorLastUsedSet(Set<UUID> detectorsLastUsedTimeSet) {
         int counter = 0;
-        for (Iterator<UUID> iterator = detectorsLastUsedTimeSetClone.iterator(); iterator.hasNext(); ) {
+        for (Iterator<UUID> iterator = detectorsLastUsedTimeSet.iterator(); iterator.hasNext(); ) {
             UUID detectorUuid = iterator.next();
             try {
                 detectorSource.updatedDetectorLastUsed(detectorUuid);

--- a/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
+++ b/anomdetect/src/main/java/com/expedia/adaptivealerting/anomdetect/DetectorManager.java
@@ -285,16 +285,18 @@ public class DetectorManager {
         if (updateDurationInSeconds <= 0 || detectorsLastUsedTimeToBeUpdatedSet.isEmpty()) {
             return;
         }
-
-        log.info("Updating last used time for a total of {} invoked detectors", detectorsLastUsedTimeToBeUpdatedSet.size());
         processDetectorsLastUsedTimeSet();
         detectorsLastUsedSyncedTillTime = currentTime;
     }
 
-    //Set.remove() during iteration throws a ConcurrentModificationException, so have to use Iterator.remove() instead. [KS]
     private void processDetectorsLastUsedTimeSet() {
+
+        Set<UUID> detectorsLastUsedTimeSetClone = buildDetectorLastUsedSetClone();
+
+        log.info("Updating last used time for a total of {} invoked detectors", detectorsLastUsedTimeSetClone.size());
+
         int counter = 0;
-        for (Iterator<UUID> iterator = detectorsLastUsedTimeToBeUpdatedSet.iterator(); iterator.hasNext(); ) {
+        for (Iterator<UUID> iterator = detectorsLastUsedTimeSetClone.iterator(); iterator.hasNext(); ) {
             UUID detectorUuid = iterator.next();
             try {
                 detectorSource.updatedDetectorLastUsed(detectorUuid);
@@ -304,6 +306,18 @@ public class DetectorManager {
             }
             iterator.remove();
         }
+
         log.info("Updated last used time for a total of {} invoked detectors", counter);
+    }
+
+    private Set<UUID> buildDetectorLastUsedSetClone() {
+        log.info("Cloning last used time set of size {}", detectorsLastUsedTimeToBeUpdatedSet.size());
+
+        Set<UUID> detectorsLastUsedTimeSetClone = new HashSet<>();
+        for (UUID detectorUuid : detectorsLastUsedTimeToBeUpdatedSet) {
+            detectorsLastUsedTimeSetClone.add(detectorUuid);
+        }
+        detectorsLastUsedTimeToBeUpdatedSet.removeAll(detectorsLastUsedTimeSetClone);
+        return detectorsLastUsedTimeSetClone;
     }
 }


### PR DESCRIPTION
Use ConcurrentLinkedQueue to maintain the UUIDs for which `lastAccessedTime` needs to be updated and convert it into a HashSet before calling the elastic search to prevent duplicate calls.

Unique Detector UUIDs
```
2020-06-04 12:38:09 INFO  DetectorManager:296 () - Detectors last used time queue size 50
2020-06-04 12:38:09 INFO  DetectorManager:299 () - Updating last used time for a total of 50 invoked detectors
2020-06-04 12:38:09 INFO  DetectorManager:325 () - Updated last used time for a total of 50 invoked detectors
```

Duplicate Detector UUIDs
```
2020-06-04 12:38:09 INFO  DetectorManager:296 () - Detectors last used time queue size 4
2020-06-04 12:38:09 INFO  DetectorManager:299 () - Updating last used time for a total of 1 invoked detectors
2020-06-04 12:38:09 INFO  DetectorManager:325 () - Updated last used time for a total of 1 invoked detectors
```
Invalid Detector UUIDs
```
2020-06-04 12:38:09 INFO  DetectorManager:296 () - Detectors last used time queue size 2
2020-06-04 12:38:09 INFO  DetectorManager:299 () - Updating last used time for a total of 2 invoked detectors
2020-06-04 12:38:09 ERROR DetectorManager:321 () - Error updating last accessed time for detector UUID: ab5fea71-094d-48a7-9b25-caf6a7715704
2020-06-04 12:38:09 INFO  DetectorManager:325 () - Updated last used time for a total of 1 invoked detectors
```

