### PR TITLE
Updated delete mappings by detector uuid endpoint

### DIFF
--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorMappingController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorMappingController.java
@@ -91,7 +91,7 @@ public class DetectorMappingController {
         return matchingDetectorMappings;
     }
 
-    @RequestMapping(value = "/search/findByDetector", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/deleteByDetectorUuid", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     public void deleteMappingsByDetectorUUID(@RequestParam UUID uuid) {
         AssertUtil.notNull(uuid, "detector uuid can't be null");

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorMappingController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorMappingController.java
@@ -91,7 +91,7 @@ public class DetectorMappingController {
         return matchingDetectorMappings;
     }
 
-    @RequestMapping(value = "/deleteByDetectorUuid", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/deleteMappingsByDetectorUuid", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     public void deleteMappingsByDetectorUUID(@RequestParam UUID uuid) {
         AssertUtil.notNull(uuid, "detector uuid can't be null");


### PR DESCRIPTION
Updated delete mappings by detector uuid endpoint since `/search/findByDetector` was a bit confusing and meant one could use it for search. 