### PR TITLE
Combining AA scheduler data to modelService detector document

### DIFF
--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -94,6 +94,17 @@ public class Detector {
         @Field(type = FieldType.Text)
         private String trainingInterval;
 
+        public TrainingMetaData() {
+
+        }
+
+        public TrainingMetaData(TrainingMetaData originalTrainingMeta) {
+            dateTrainingLastRun = originalTrainingMeta.dateTrainingLastRun;
+            dateTrainingNextRun = originalTrainingMeta.dateTrainingNextRun;
+            trainingInterval = originalTrainingMeta.trainingInterval;
+            cronSchedule = originalTrainingMeta.cronSchedule;
+        }
+
         //For backward compatibility for with request validator
         public Map<String, Object> toMap() {
             return new HashMap() {{

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -94,6 +94,7 @@ public class Detector {
         @Field(type = FieldType.Text)
         private String trainingInterval;
 
+        //For backward compatibility for with request validator
         public Map<String, Object> toMap() {
             return new HashMap() {{
                     put("dateLastTrained", dateLastTrained);
@@ -111,10 +112,10 @@ public class Detector {
         private Map<String, Object> hyperparams;
 
         @Field(type = FieldType.Object)
-        private Map<String, Object> params;
+        private TrainingMetaData trainingMetaData;
 
         @Field(type = FieldType.Object)
-        private TrainingMetaData trainingMetaData;
+        private Map<String, Object> params;
 
         //For backward compatibility for with request validator
         public Map<String, Object> toMap() {
@@ -122,11 +123,11 @@ public class Detector {
                     if (hyperparams != null) {
                         put("hyperparams", hyperparams);
                     }
-                    if (params != null) {
-                        put("params", params);
-                    }
                     if (trainingMetaData != null) {
                         put("trainingMetaData", trainingMetaData.toMap());
+                    }
+                    if (params != null) {
+                        put("params", params);
                     }
                 }};
         }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -62,14 +62,6 @@ public class Detector {
     @Field(type = FieldType.Object)
     private Meta meta;
 
-    public void setTrainingMetaData(TrainingMetaData trainingMetaData) {
-        this.getDetectorConfig().setTrainingMetaData(trainingMetaData);
-    }
-
-    public TrainingMetaData getTrainingMetaData() {
-        return this.getDetectorConfig().getTrainingMetaData();
-    }
-
     @Data
     public static class Meta {
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -16,7 +16,10 @@
 package com.expedia.adaptivealerting.modelservice.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
@@ -78,6 +81,9 @@ public class Detector {
     }
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(toBuilder = true)
     public static class TrainingMetaData {
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
@@ -94,17 +100,6 @@ public class Detector {
         @Field(type = FieldType.Text)
         private String trainingInterval;
 
-        public TrainingMetaData() {
-
-        }
-
-        public TrainingMetaData(TrainingMetaData originalTrainingMeta) {
-            dateTrainingLastRun = originalTrainingMeta.dateTrainingLastRun;
-            dateTrainingNextRun = originalTrainingMeta.dateTrainingNextRun;
-            trainingInterval = originalTrainingMeta.trainingInterval;
-            cronSchedule = originalTrainingMeta.cronSchedule;
-        }
-
         //For backward compatibility for with request validator
         public Map<String, Object> toMap() {
             return new HashMap() {{
@@ -117,6 +112,9 @@ public class Detector {
     }
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class DetectorConfig {
 
         @Field(type = FieldType.Object)

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -26,6 +26,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -56,10 +57,18 @@ public class Detector {
     private boolean trusted;
 
     @Field(type = FieldType.Object)
-    private Map<String, Object> detectorConfig;
+    private DetectorConfig detectorConfig;
 
     @Field(type = FieldType.Object)
     private Meta meta;
+
+    public void setTrainingMetaData(TrainingMetaData trainingMetaData) {
+        this.getDetectorConfig().setTrainingMetaData(trainingMetaData);
+    }
+
+    public TrainingMetaData getTrainingMetaData() {
+        return this.getDetectorConfig().getTrainingMetaData();
+    }
 
     @Data
     public static class Meta {
@@ -76,4 +85,58 @@ public class Detector {
         private Date dateLastUpdated;
     }
 
+    @Data
+    public static class TrainingMetaData {
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date dateLastTrained;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
+        private Date dateNextTraining;
+
+        @Field(type = FieldType.Text)
+        private String cronSchedule;
+
+        @Field(type = FieldType.Text)
+        private String trainingInterval;
+
+        public Map<String, Object> toMap() {
+            return new HashMap() {{
+                    put("dateLastTrained", dateLastTrained);
+                    put("dateNextTraining", dateNextTraining);
+                    put("cronSchedule", cronSchedule);
+                    put("trainingInterval", trainingInterval);
+                }};
+        }
+    }
+
+    @Data
+    public static class DetectorConfig {
+
+        @Field(type = FieldType.Object)
+        private Map<String, Object> hyperparams;
+
+        @Field(type = FieldType.Object)
+        private Map<String, Object> params;
+
+        @Field(type = FieldType.Object)
+        private TrainingMetaData trainingMetaData;
+
+        //For backward compatibility for with request validator
+        public Map<String, Object> toMap() {
+            return new HashMap() {{
+                    if (hyperparams != null) {
+                        put("hyperparams", hyperparams);
+                    }
+                    if (params != null) {
+                        put("params", params);
+                    }
+                    if (trainingMetaData != null) {
+                        put("trainingMetaData", trainingMetaData.toMap());
+                    }
+                }};
+        }
+    }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/entity/Detector.java
@@ -82,11 +82,11 @@ public class Detector {
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
-        private Date dateLastTrained;
+        private Date dateTrainingLastRun;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd HH:mm:ss")
-        private Date dateNextTraining;
+        private Date dateTrainingNextRun;
 
         @Field(type = FieldType.Text)
         private String cronSchedule;
@@ -97,8 +97,8 @@ public class Detector {
         //For backward compatibility for with request validator
         public Map<String, Object> toMap() {
             return new HashMap() {{
-                    put("dateLastTrained", dateLastTrained);
-                    put("dateNextTraining", dateNextTraining);
+                    put("dateTrainingLastRun", dateTrainingLastRun);
+                    put("dateTrainingNextRun", dateTrainingNextRun);
                     put("cronSchedule", cronSchedule);
                     put("trainingInterval", trainingInterval);
                 }};

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
@@ -34,7 +34,7 @@ public interface DetectorRepository extends ElasticsearchRepository<Detector, St
 
     List<Detector> findByMeta_DateLastAccessedLessThan(String date);
 
-    List<Detector> findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(String date);
+    List<Detector> findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(String date);
 
     void deleteByUuid(String uuid);
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
@@ -41,3 +41,4 @@ public interface DetectorRepository extends ElasticsearchRepository<Detector, St
     boolean existsById(String primaryKey);
 
 }
+

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/repo/DetectorRepository.java
@@ -34,6 +34,8 @@ public interface DetectorRepository extends ElasticsearchRepository<Detector, St
 
     List<Detector> findByMeta_DateLastAccessedLessThan(String date);
 
+    List<Detector> findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(String date);
+
     void deleteByUuid(String uuid);
 
     boolean existsById(String primaryKey);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
@@ -43,13 +43,13 @@ public interface DetectorService {
 
     List<Detector> getLastUsedDetectors(int noOfDays);
 
-    List<Detector> getByTrainingNextRunLessThan();
+    List<Detector> getDetectorsToBeTrained();
 
     void updateDetector(String uuid, Detector detector);
 
     void updateDetectorLastUsed(String uuid);
 
-    void updateTrainingRunTime(String uuid, long nextRun);
+    void updateDetectorTrainingTime(String uuid, long nextRun);
 
     void deleteDetector(String uuid);
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
@@ -43,7 +43,7 @@ public interface DetectorService {
 
     List<Detector> getLastUsedDetectors(int noOfDays);
 
-    List<Detector> getByNextRunLessThanOrNull();
+    List<Detector> getByTrainingNextRunLessThan();
 
     void updateDetector(String uuid, Detector detector);
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
@@ -43,9 +43,13 @@ public interface DetectorService {
 
     List<Detector> getLastUsedDetectors(int noOfDays);
 
+    List<Detector> getByNextRunLessThanOrNull();
+
     void updateDetector(String uuid, Detector detector);
 
     void updateDetectorLastUsed(String uuid);
+
+    void updateTrainingRunTime(String uuid, long nextRun);
 
     void deleteDetector(String uuid);
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -139,9 +139,6 @@ public class DetectorServiceImpl implements DetectorService {
         notNull(uuid, "uuid can't be null");
         MDC.put("DetectorUuid", uuid);
         Detector detectorToBeUpdated = repository.findByUuid(uuid);
-        if (detectorToBeUpdated.getDetectorConfig() == null) {
-            detectorToBeUpdated.setDetectorConfig(new Detector.DetectorConfig());
-        }
         detectorToBeUpdated.getDetectorConfig().setTrainingMetaData(buildTrainingMeta(detectorToBeUpdated, nextRun));
         repository.save(detectorToBeUpdated);
     }
@@ -193,9 +190,6 @@ public class DetectorServiceImpl implements DetectorService {
 
     private Detector.DetectorConfig mergeDetectorConfig(Detector.DetectorConfig existingConfig,
                                                         Detector.DetectorConfig newConfig) {
-        if (existingConfig == null) {
-            existingConfig = new Detector.DetectorConfig();
-        }
         if (newConfig == null) {
             newConfig = new Detector.DetectorConfig();
         }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -114,7 +114,7 @@ public class DetectorServiceImpl implements DetectorService {
         MDC.put("DetectorUuid", uuid);
 
         Detector detectorToBeUpdated = repository.findByUuid(uuid);
-        DetectorConfig detectorConfigToUpdate = DetectorDataUtil.mergeDetectorConfig(
+        DetectorConfig detectorConfigToUpdate = DetectorDataUtil.buildMergedDetectorConfig(
             detectorToBeUpdated.getDetectorConfig(),
             detector.getDetectorConfig());
         detectorToBeUpdated.setDetectorConfig(detectorConfigToUpdate);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.expedia.adaptivealerting.anomdetect.util.AssertUtil.isNull;
@@ -116,7 +117,7 @@ public class DetectorServiceImpl implements DetectorService {
         Detector detectorToBeUpdated = repository.findByUuid(uuid);
         DetectorConfig detectorConfigToUpdate = DetectorDataUtil.buildMergedDetectorConfig(
             detectorToBeUpdated.getDetectorConfig(),
-            detector.getDetectorConfig());
+            Optional.ofNullable(detector.getDetectorConfig()));
         detectorToBeUpdated.setDetectorConfig(detectorConfigToUpdate);
         detectorToBeUpdated.setMeta(DetectorDataUtil.buildLastUpdatedDetectorMeta(detector));
         RequestValidator.validateDetector(detectorToBeUpdated);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -100,7 +100,7 @@ public class DetectorServiceImpl implements DetectorService {
     }
 
     @Override
-    public List<Detector> getByTrainingNextRunLessThan() {
+    public List<Detector> getDetectorsToBeTrained() {
         val now = DateUtil.now().toInstant();
         val date = DateUtil.toUtcDateString(now);
         List<Detector> detectorList = repository.findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(date);
@@ -135,7 +135,7 @@ public class DetectorServiceImpl implements DetectorService {
     }
 
     @Override
-    public void updateTrainingRunTime(String uuid, long nextRun) {
+    public void updateDetectorTrainingTime(String uuid, long nextRun) {
         notNull(uuid, "uuid can't be null");
         MDC.put("DetectorUuid", uuid);
         Detector detectorToBeUpdated = repository.findByUuid(uuid);

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -173,8 +173,8 @@ public class DetectorServiceImpl implements DetectorService {
     private Detector.TrainingMetaData buildTrainingMeta(Detector detector, Long nextRun) {
         Detector.TrainingMetaData trainingMetaDataBlock = buildDetectorTrainingMeta(detector);
         Date nowDate = DateUtil.now();
-        trainingMetaDataBlock.setDateLastTrained(nowDate);
-        trainingMetaDataBlock.setDateNextTraining(new Date(nextRun));
+        trainingMetaDataBlock.setDateTrainingLastRun(nowDate);
+        trainingMetaDataBlock.setDateTrainingNextRun(new Date(nextRun));
         return trainingMetaDataBlock;
     }
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -103,6 +103,7 @@ public class DetectorServiceImpl implements DetectorService {
     public List<Detector> getByNextRunLessThanOrNull() {
         val now = DateUtil.now().toInstant();
         val date = DateUtil.toUtcDateString(now);
+        //TODO: handle isNULL condition....
         List<Detector> detectorList = repository.findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(date);
 
         return detectorList;
@@ -136,7 +137,10 @@ public class DetectorServiceImpl implements DetectorService {
         notNull(uuid, "uuid can't be null");
         MDC.put("DetectorUuid", uuid);
         Detector detectorToBeUpdated = repository.findByUuid(uuid);
-        detectorToBeUpdated.setTrainingMetaData(buildTrainingMeta(detectorToBeUpdated, nextRun));
+        if (detectorToBeUpdated.getDetectorConfig() == null) {
+            detectorToBeUpdated.setDetectorConfig(new Detector.DetectorConfig());
+        }
+        detectorToBeUpdated.getDetectorConfig().setTrainingMetaData(buildTrainingMeta(detectorToBeUpdated, nextRun));
         repository.save(detectorToBeUpdated);
     }
 
@@ -181,7 +185,7 @@ public class DetectorServiceImpl implements DetectorService {
     }
 
     private Detector.TrainingMetaData buildDetectorTrainingMeta(Detector detector) {
-        Detector.TrainingMetaData metaBlock = detector.getTrainingMetaData();
-        return (metaBlock == null) ? new Detector.TrainingMetaData() : detector.getTrainingMetaData();
+        Detector.TrainingMetaData metaBlock = detector.getDetectorConfig().getTrainingMetaData();
+        return (metaBlock == null) ? new Detector.TrainingMetaData() : metaBlock;
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -105,7 +105,7 @@ public class DetectorServiceImpl implements DetectorService {
     public List<Detector> getDetectorsToBeTrained() {
         val now = DateUtil.now().toInstant();
         val date = DateUtil.toUtcDateString(now);
-        return repository.findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(date);
+        return repository.findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(date);
     }
 
     @Override

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
@@ -23,6 +23,7 @@ import lombok.val;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Optional;
 
 public class DetectorDataUtil {
 
@@ -67,19 +68,19 @@ public class DetectorDataUtil {
     }
 
     public static DetectorConfig buildMergedDetectorConfig(DetectorConfig existingConfig,
-                                                           DetectorConfig newConfig) {
-        val newConfigExists = newConfig != null;
-        val trainingMetaData = (newConfigExists && newConfig.getTrainingMetaData() != null) ?
-               newConfig.getTrainingMetaData(): existingConfig.getTrainingMetaData();
-        val hyperParamsMap = newConfigExists && newConfig.getHyperparams() != null ?
-            newConfig.getHyperparams(): existingConfig.getHyperparams();
-        val paramsMap = newConfigExists && newConfig.getParams() != null ?
-            newConfig.getParams(): existingConfig.getParams();
+                                                           Optional<DetectorConfig> newConfigOptional) {
+
+        val trainingMetaData = newConfigOptional.map(DetectorConfig::getTrainingMetaData)
+            .orElse(existingConfig.getTrainingMetaData());
+        val hyperParamsMap = newConfigOptional.map(DetectorConfig::getHyperparams)
+            .orElse(existingConfig.getHyperparams());
+        val paramsMap = newConfigOptional.map(DetectorConfig::getParams)
+            .orElse(existingConfig.getParams());
 
         return DetectorConfig.builder()
-            .hyperparams(hyperParamsMap != null ? new HashMap<>(hyperParamsMap) : null)
-            .trainingMetaData(trainingMetaData != null ? trainingMetaData.toBuilder().build(): null)
-            .params(paramsMap != null ? new HashMap<>(paramsMap) : null)
+            .hyperparams(hyperParamsMap != null ? new HashMap<>(hyperParamsMap) : new HashMap<>())
+            .trainingMetaData(trainingMetaData != null ? trainingMetaData.toBuilder().build(): new TrainingMetaData())
+            .params(paramsMap != null ? new HashMap<>(paramsMap) : new HashMap<>())
             .build();
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018-2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.adaptivealerting.modelservice.util;
+
+import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.entity.Detector.Meta;
+import com.expedia.adaptivealerting.modelservice.entity.Detector.DetectorConfig;
+import com.expedia.adaptivealerting.modelservice.entity.Detector.TrainingMetaData;
+import lombok.val;
+
+import java.util.Date;
+import java.util.HashMap;
+
+public class DetectorDataUtil {
+
+    public static Meta buildNewDetectorMeta(Detector detector) {
+        Meta metaBlock = buildDetectorMeta(detector);
+        Date nowDate = DateUtil.now();
+        metaBlock.setDateLastUpdated(nowDate);
+        metaBlock.setDateLastAccessed(nowDate);
+        return metaBlock;
+    }
+
+    public static Meta buildLastUpdatedDetectorMeta(Detector detector) {
+        Meta metaBlock = buildDetectorMeta(detector);
+        Date nowDate = DateUtil.now();
+        metaBlock.setDateLastUpdated(nowDate);
+        return metaBlock;
+    }
+
+    public static Meta buildLastUsedDetectorMeta(Detector detector) {
+        Meta metaBlock = buildDetectorMeta(detector);
+        Date nowDate = DateUtil.now();
+        metaBlock.setDateLastAccessed(nowDate);
+        return metaBlock;
+    }
+
+    private static Meta buildDetectorMeta(Detector detector) {
+        Meta metaBlock = detector.getMeta();
+        return (metaBlock == null) ? new Meta() : detector.getMeta();
+    }
+
+    public static TrainingMetaData buildDetectorTrainingMeta(Detector detector) {
+        TrainingMetaData metaBlock = detector.getDetectorConfig().getTrainingMetaData();
+        return (metaBlock == null) ? new TrainingMetaData() : metaBlock;
+    }
+
+    public static TrainingMetaData buildUpdatedRuntimeTrainingMeta(Detector detector, Long nextRun) {
+        TrainingMetaData trainingMetaDataBlock = buildDetectorTrainingMeta(detector);
+        Date nowDate = DateUtil.now();
+        trainingMetaDataBlock.setDateTrainingLastRun(nowDate);
+        trainingMetaDataBlock.setDateTrainingNextRun(new Date(nextRun));
+        return trainingMetaDataBlock;
+    }
+
+    public static DetectorConfig mergeDetectorConfig(DetectorConfig existingConfig,
+                                               DetectorConfig newConfig) {
+        val mergedDetectorConfig = new DetectorConfig();
+        val newConfigExists = newConfig != null;
+
+        if (newConfigExists && newConfig.getTrainingMetaData() != null) {
+            mergedDetectorConfig.setTrainingMetaData(new TrainingMetaData(newConfig.getTrainingMetaData()));
+        } else if (existingConfig.getTrainingMetaData() != null ) {
+            mergedDetectorConfig.setTrainingMetaData(new TrainingMetaData(existingConfig.getTrainingMetaData()));
+        }
+
+        if (newConfigExists && newConfig.getHyperparams() != null) {
+            mergedDetectorConfig.setHyperparams(new HashMap<>(newConfig.getHyperparams()));
+        } else if (existingConfig.getHyperparams() != null) {
+            mergedDetectorConfig.setHyperparams(new HashMap(existingConfig.getHyperparams()));
+        }
+
+        if (newConfigExists && newConfig.getParams() != null) {
+            mergedDetectorConfig.setParams(new HashMap<>(newConfig.getParams()));
+        } else if (existingConfig.getParams() != null) {
+            mergedDetectorConfig.setParams(new HashMap(existingConfig.getParams()));
+        }
+        return mergedDetectorConfig;
+    }
+}

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
@@ -91,3 +91,4 @@ public class DetectorDataUtil {
         return mergedDetectorConfig;
     }
 }
+

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/DetectorDataUtil.java
@@ -66,29 +66,20 @@ public class DetectorDataUtil {
         return trainingMetaDataBlock;
     }
 
-    public static DetectorConfig mergeDetectorConfig(DetectorConfig existingConfig,
-                                               DetectorConfig newConfig) {
-        val mergedDetectorConfig = new DetectorConfig();
+    public static DetectorConfig buildMergedDetectorConfig(DetectorConfig existingConfig,
+                                                           DetectorConfig newConfig) {
         val newConfigExists = newConfig != null;
+        val trainingMetaData = (newConfigExists && newConfig.getTrainingMetaData() != null) ?
+               newConfig.getTrainingMetaData(): existingConfig.getTrainingMetaData();
+        val hyperParamsMap = newConfigExists && newConfig.getHyperparams() != null ?
+            newConfig.getHyperparams(): existingConfig.getHyperparams();
+        val paramsMap = newConfigExists && newConfig.getParams() != null ?
+            newConfig.getParams(): existingConfig.getParams();
 
-        if (newConfigExists && newConfig.getTrainingMetaData() != null) {
-            mergedDetectorConfig.setTrainingMetaData(new TrainingMetaData(newConfig.getTrainingMetaData()));
-        } else if (existingConfig.getTrainingMetaData() != null ) {
-            mergedDetectorConfig.setTrainingMetaData(new TrainingMetaData(existingConfig.getTrainingMetaData()));
-        }
-
-        if (newConfigExists && newConfig.getHyperparams() != null) {
-            mergedDetectorConfig.setHyperparams(new HashMap<>(newConfig.getHyperparams()));
-        } else if (existingConfig.getHyperparams() != null) {
-            mergedDetectorConfig.setHyperparams(new HashMap(existingConfig.getHyperparams()));
-        }
-
-        if (newConfigExists && newConfig.getParams() != null) {
-            mergedDetectorConfig.setParams(new HashMap<>(newConfig.getParams()));
-        } else if (existingConfig.getParams() != null) {
-            mergedDetectorConfig.setParams(new HashMap(existingConfig.getParams()));
-        }
-        return mergedDetectorConfig;
+        return DetectorConfig.builder()
+            .hyperparams(hyperParamsMap != null ? new HashMap<>(hyperParamsMap) : null)
+            .trainingMetaData(trainingMetaData != null ? trainingMetaData.toBuilder().build(): null)
+            .params(paramsMap != null ? new HashMap<>(paramsMap) : null)
+            .build();
     }
 }
-

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/RequestValidator.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/util/RequestValidator.java
@@ -73,7 +73,7 @@ public class RequestValidator {
     public static void validateDetector(Detector detector) {
         DetectorDocument detectorDocument = new DetectorDocument()
                 .setUuid(detector.getUuid())
-                .setConfig(detector.getDetectorConfig())
+                .setConfig(detector.getDetectorConfig().toMap())
                 .setType(detector.getType());
         validateDetectorDocument(detectorDocument);
     }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -135,27 +135,27 @@ public class DetectorController {
         service.deleteDetector(uuid);
     }
 
-    @GetMapping(path = "/getNextTrainDetectors", produces = "application/json")
+    @GetMapping(path = "/getNextDetectorsToTrain", produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
-    public List<Detector> findByNextRun(@RequestHeader HttpHeaders headers) {
+    public List<Detector> getNextDetectorsToTrain(@RequestHeader HttpHeaders headers) {
         SpanContext parentSpanContext = trace.extractParentSpan(headers);
         Span span = trace.startSpan("find-detectors-to-train-next", parentSpanContext);
-        val detectorList = service.getByTrainingNextRunLessThan();
+        val detectorList = service.getDetectorsToBeTrained();
         span.finish();
 
         return detectorList;
     }
 
     @PostMapping(path = "/updateDetectorTrainingTime")
-    public void updateTrainingRunTime(@RequestParam String uuid,
-                                      @RequestParam Long nextRun,
-                                      @RequestHeader HttpHeaders headers) {
+    public void updateDetectorTrainingTime(@RequestParam String uuid,
+                                           @RequestParam Long nextRun,
+                                           @RequestHeader HttpHeaders headers) {
         Assert.notNull(uuid, "uuid can't be null");
         Assert.notNull(nextRun, "nextRun can't be null");
         SpanContext parentSpanContext = trace.extractParentSpan(headers);
         Span span = trace.startSpan("update-detector-training-time", parentSpanContext);
         span.setTag("detectorUuid", uuid);
-        service.updateTrainingRunTime(uuid, nextRun);
+        service.updateDetectorTrainingTime(uuid, nextRun);
         span.finish();
     }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -134,4 +134,28 @@ public class DetectorController {
     public void deleteDetector(@RequestParam String uuid) {
         service.deleteDetector(uuid);
     }
+
+    @GetMapping(path = "/getNextTrainDetectors", produces = "application/json")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Detector> findByNextRun(@RequestHeader HttpHeaders headers) {
+        SpanContext parentSpanContext = trace.extractParentSpan(headers);
+        Span span = trace.startSpan("find-detectors-to-train-next", parentSpanContext);
+        val detectorList = service.getByNextRunLessThanOrNull();
+        span.finish();
+
+        return detectorList;
+    }
+
+    @PostMapping(path = "/updateDetectorTrainingTime")
+    public void updateTrainingRunTime(@RequestParam String uuid,
+                                      @RequestParam Long nextRun,
+                                      @RequestHeader HttpHeaders headers) {
+        Assert.notNull(uuid, "uuid can't be null");
+        Assert.notNull(nextRun, "nextRun can't be null");
+        SpanContext parentSpanContext = trace.extractParentSpan(headers);
+        Span span = trace.startSpan("update-detector-training-time", parentSpanContext);
+        span.setTag("detectorUuid", uuid);
+        service.updateTrainingRunTime(uuid, nextRun);
+        span.finish();
+    }
 }

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -135,9 +135,9 @@ public class DetectorController {
         service.deleteDetector(uuid);
     }
 
-    @GetMapping(path = "/getNextDetectorsToTrain", produces = "application/json")
+    @GetMapping(path = "/getDetectorsToTrain", produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
-    public List<Detector> getNextDetectorsToTrain(@RequestHeader HttpHeaders headers) {
+    public List<Detector> getDetectorsToTrain(@RequestHeader HttpHeaders headers) {
         SpanContext parentSpanContext = trace.extractParentSpan(headers);
         Span span = trace.startSpan("find-detectors-to-train-next", parentSpanContext);
         val detectorList = service.getDetectorsToBeTrained();

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -140,7 +140,7 @@ public class DetectorController {
     public List<Detector> findByNextRun(@RequestHeader HttpHeaders headers) {
         SpanContext parentSpanContext = trace.extractParentSpan(headers);
         Span span = trace.startSpan("find-detectors-to-train-next", parentSpanContext);
-        val detectorList = service.getByNextRunLessThanOrNull();
+        val detectorList = service.getByTrainingNextRunLessThan();
         span.finish();
 
         return detectorList;

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -4,6 +4,7 @@ import com.expedia.adaptivealerting.modelservice.entity.Detector;
 import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
 import com.expedia.adaptivealerting.modelservice.repo.DetectorRepository;
 import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
+import com.expedia.adaptivealerting.modelservice.util.DateUtil;
 import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
@@ -166,7 +167,18 @@ public class DetectorServiceImplTest {
     @Test
     public void testUpdateDetectorTrainingTime() {
         val uuid = this.someUuid.toString();
-        serviceUnderTest.updateDetectorTrainingTime(uuid, 0L);
+        val timestamp = DateUtil.toUtcDate("2020-07-15 20:00:00").toInstant().toEpochMilli();
+        serviceUnderTest.updateDetectorTrainingTime(uuid, timestamp);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testUpdateDetectorTrainingTime_withPreviousTrainingInfo() {
+        fillDetectorConfigValues(legalParamsDetector);
+        val uuid = this.someUuid.toString();
+        val timestamp = DateUtil.toUtcDate("2020-07-20 20:00:00").toInstant().toEpochMilli();
+        serviceUnderTest.updateDetectorTrainingTime(uuid, timestamp);
         verify(repository, times(1)).findByUuid(someUuid.toString());
         verify(repository, times(1)).save(legalParamsDetector);
     }
@@ -189,6 +201,8 @@ public class DetectorServiceImplTest {
     private void fillDetectorConfigValues(Detector detector) {
         val trainingMetaData = new Detector.TrainingMetaData();
         trainingMetaData.setCronSchedule("42 1 * * 3");
+        trainingMetaData.setDateLastTrained(DateUtil.toUtcDate("2020-07-15 20:00:00"));
+        trainingMetaData.setDateNextTraining(DateUtil.toUtcDate("2020-07-22 20:00:00"));
         detector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
 
         val hyperParams = new HashMap<String, Object>();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.expedia.adaptivealerting.modelservice.service;
 
 import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.entity.Detector.TrainingMetaData;
 import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundException;
 import com.expedia.adaptivealerting.modelservice.repo.DetectorRepository;
 import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
@@ -199,7 +200,7 @@ public class DetectorServiceImplTest {
     }
 
     private void fillDetectorConfigValues(Detector detector) {
-        val trainingMetaData = new Detector.TrainingMetaData();
+        val trainingMetaData = new TrainingMetaData();
         trainingMetaData.setCronSchedule("42 1 * * 3");
         trainingMetaData.setDateTrainingLastRun(DateUtil.toUtcDate("2020-07-15 20:00:00"));
         trainingMetaData.setDateTrainingNextRun(DateUtil.toUtcDate("2020-07-22 20:00:00"));

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -137,6 +137,20 @@ public class DetectorServiceImplTest {
         verify(repository, times(1)).deleteByUuid(someUuidStr);
     }
 
+    @Test
+    public void testGetByNextRunLessThanOrNull() {
+        serviceUnderTest.getByNextRunLessThanOrNull();
+        verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(anyString());
+    }
+
+    @Test
+    public void testUpdateTrainingRunTime() {
+        val uuid = this.someUuid.toString();
+        serviceUnderTest.updateTrainingRunTime(uuid, 0L);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
     private void initTestObjects() {
         this.someUuid = UUID.randomUUID();
         val mom = ObjectMother.instance();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -139,7 +139,7 @@ public class DetectorServiceImplTest {
 
     @Test
     public void testGetByNextRunLessThanOrNull() {
-        serviceUnderTest.getByNextRunLessThanOrNull();
+        serviceUnderTest.getByTrainingNextRunLessThan();
         verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(anyString());
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -162,7 +162,7 @@ public class DetectorServiceImplTest {
     @Test
     public void testGetDetectorsToBeTrained() {
         serviceUnderTest.getDetectorsToBeTrained();
-        verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(anyString());
+        verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(anyString());
     }
 
     @Test

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -138,13 +138,13 @@ public class DetectorServiceImplTest {
     }
 
     @Test
-    public void testGetByNextRunLessThanOrNull() {
+    public void testGetDetectorsToBeTrained() {
         serviceUnderTest.getDetectorsToBeTrained();
         verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(anyString());
     }
 
     @Test
-    public void testUpdateTrainingRunTime() {
+    public void testUpdateDetectorTrainingTime() {
         val uuid = this.someUuid.toString();
         serviceUnderTest.updateDetectorTrainingTime(uuid, 0L);
         verify(repository, times(1)).findByUuid(someUuid.toString());

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -124,6 +124,16 @@ public class DetectorServiceImplTest {
     }
 
     @Test
+    public void testUpdateDetectorWithTrainingMetaData() {
+        Detector.TrainingMetaData trainingMetaData = new Detector.TrainingMetaData();
+        trainingMetaData.setCronSchedule("42 1 * * 3");
+        legalParamsDetector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
+        serviceUnderTest.updateDetector(someUuid.toString(), legalParamsDetector);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
     public void testUpdateDetectorLastUsed() {
         serviceUnderTest.updateDetectorLastUsed(someUuid.toString());
         verify(repository, times(1)).findByUuid(someUuid.toString());

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -200,10 +200,11 @@ public class DetectorServiceImplTest {
     }
 
     private void fillDetectorConfigValues(Detector detector) {
-        val trainingMetaData = new TrainingMetaData();
-        trainingMetaData.setCronSchedule("42 1 * * 3");
-        trainingMetaData.setDateTrainingLastRun(DateUtil.toUtcDate("2020-07-15 20:00:00"));
-        trainingMetaData.setDateTrainingNextRun(DateUtil.toUtcDate("2020-07-22 20:00:00"));
+        val trainingMetaData = TrainingMetaData.builder()
+            .cronSchedule("42 1 * * 3")
+            .dateTrainingLastRun(DateUtil.toUtcDate("2020-07-15 20:00:00"))
+            .dateTrainingNextRun(DateUtil.toUtcDate("2020-07-22 20:00:00"))
+            .build();
         detector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
 
         val hyperParams = new HashMap<String, Object>();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -139,14 +139,14 @@ public class DetectorServiceImplTest {
 
     @Test
     public void testGetByNextRunLessThanOrNull() {
-        serviceUnderTest.getByTrainingNextRunLessThan();
+        serviceUnderTest.getDetectorsToBeTrained();
         verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateNextTrainingLessThan(anyString());
     }
 
     @Test
     public void testUpdateTrainingRunTime() {
         val uuid = this.someUuid.toString();
-        serviceUnderTest.updateTrainingRunTime(uuid, 0L);
+        serviceUnderTest.updateDetectorTrainingTime(uuid, 0L);
         verify(repository, times(1)).findByUuid(someUuid.toString());
         verify(repository, times(1)).save(legalParamsDetector);
     }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -124,11 +125,20 @@ public class DetectorServiceImplTest {
     }
 
     @Test
-    public void testUpdateDetectorWithTrainingMetaData() {
-        Detector.TrainingMetaData trainingMetaData = new Detector.TrainingMetaData();
-        trainingMetaData.setCronSchedule("42 1 * * 3");
-        legalParamsDetector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
-        serviceUnderTest.updateDetector(someUuid.toString(), legalParamsDetector);
+    public void testUpdateDetectorWithConfigData() {
+        val detectorToUpdate = getDetectorToUpdate();
+        fillDetectorConfigValues(legalParamsDetector);
+        serviceUnderTest.updateDetector(someUuid.toString(), detectorToUpdate);
+        verify(repository, times(1)).findByUuid(someUuid.toString());
+        verify(repository, times(1)).save(legalParamsDetector);
+    }
+
+    @Test
+    public void testUpdateDetectorWithNoConfig() {
+        val detectorToUpdate = getDetectorToUpdate();
+        detectorToUpdate.setDetectorConfig(null); // No config data passed in update
+        fillDetectorConfigValues(legalParamsDetector);
+        serviceUnderTest.updateDetector(someUuid.toString(), detectorToUpdate);
         verify(repository, times(1)).findByUuid(someUuid.toString());
         verify(repository, times(1)).save(legalParamsDetector);
     }
@@ -166,6 +176,24 @@ public class DetectorServiceImplTest {
         val mom = ObjectMother.instance();
         this.legalParamsDetector = mom.buildDetector();
         legalParamsDetector.setUuid(someUuid);
+    }
+
+    private Detector getDetectorToUpdate() {
+        val mom = ObjectMother.instance();
+        val detectorToUpdate = mom.buildDetector();
+        detectorToUpdate.setUuid(someUuid);
+
+        return detectorToUpdate;
+    }
+
+    private void fillDetectorConfigValues(Detector detector) {
+        val trainingMetaData = new Detector.TrainingMetaData();
+        trainingMetaData.setCronSchedule("42 1 * * 3");
+        detector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
+
+        val hyperParams = new HashMap<String, Object>();
+        hyperParams.put("hampel_n_signma", 4);
+        detector.getDetectorConfig().setHyperparams(hyperParams);
     }
 
     private void initDependencies() {

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -201,8 +201,8 @@ public class DetectorServiceImplTest {
     private void fillDetectorConfigValues(Detector detector) {
         val trainingMetaData = new Detector.TrainingMetaData();
         trainingMetaData.setCronSchedule("42 1 * * 3");
-        trainingMetaData.setDateLastTrained(DateUtil.toUtcDate("2020-07-15 20:00:00"));
-        trainingMetaData.setDateNextTraining(DateUtil.toUtcDate("2020-07-22 20:00:00"));
+        trainingMetaData.setDateTrainingLastRun(DateUtil.toUtcDate("2020-07-15 20:00:00"));
+        trainingMetaData.setDateTrainingNextRun(DateUtil.toUtcDate("2020-07-22 20:00:00"));
         detector.getDetectorConfig().setTrainingMetaData(trainingMetaData);
 
         val hyperParams = new HashMap<String, Object>();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
@@ -66,7 +66,7 @@ public class ObjectMother {
         val detector = new DetectorDocument();
         detector.setCreatedBy("user");
         detector.setType("constant-detector");
-        detector.setConfig(buildDetectorConfig());
+        detector.setConfig(buildDetectorConfig().toMap());
         return detector;
     }
 
@@ -109,9 +109,9 @@ public class ObjectMother {
         return expression;
     }
 
-    private Map<String, Object> buildDetectorConfig() {
-        Map<String, Object> detectorConfig = new HashMap<>();
-        detectorConfig.put("params", getLegalDetectorParams());
+    private Detector.DetectorConfig buildDetectorConfig() {
+        Detector.DetectorConfig detectorConfig = new Detector.DetectorConfig();
+        detectorConfig.setParams(getLegalDetectorParams());
         return detectorConfig;
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/test/ObjectMother.java
@@ -18,6 +18,7 @@ package com.expedia.adaptivealerting.modelservice.test;
 import com.expedia.adaptivealerting.anomdetect.source.DetectorDocument;
 import com.expedia.adaptivealerting.modelservice.domain.mapping.*;
 import com.expedia.adaptivealerting.modelservice.entity.Detector;
+import com.expedia.adaptivealerting.modelservice.entity.Detector.DetectorConfig;
 import com.expedia.adaptivealerting.modelservice.web.request.AnomalyRequest;
 import com.expedia.adaptivealerting.modelservice.metricsource.MetricSourceResult;
 import com.expedia.adaptivealerting.modelservice.util.DateUtil;
@@ -109,8 +110,8 @@ public class ObjectMother {
         return expression;
     }
 
-    private Detector.DetectorConfig buildDetectorConfig() {
-        Detector.DetectorConfig detectorConfig = new Detector.DetectorConfig();
+    private DetectorConfig buildDetectorConfig() {
+        DetectorConfig detectorConfig = new DetectorConfig();
         detectorConfig.setParams(getLegalDetectorParams());
         return detectorConfig;
     }

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -211,7 +211,7 @@ public class DetectorControllerTest {
         when(trace.startSpan("find-detectors-to-train-next", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
 
         controllerUnderTest.findByNextRun(httpHeaders);
-        verify(detectorService, times(1)).getByNextRunLessThanOrNull();
+        verify(detectorService, times(1)).getByTrainingNextRunLessThan();
     }
 
     @Test

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -204,14 +204,14 @@ public class DetectorControllerTest {
     }
 
     @Test
-    public void testGetNextDetectorsToTrain() {
+    public void testGetDetectorsToTrain() {
         val testDetectorMappingSpanContext = new SpanContext(UUID.randomUUID(), UUID.randomUUID(),
             UUID.randomUUID());
         val testChildSpan = noOpsTracer.buildSpan("find-detectors-to-train-next").asChildOf(testDetectorMappingSpanContext).start();
         when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
         when(trace.startSpan("find-detectors-to-train-next", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
 
-        controllerUnderTest.getNextDetectorsToTrain(httpHeaders);
+        controllerUnderTest.getDetectorsToTrain(httpHeaders);
         verify(detectorService, times(1)).getDetectorsToBeTrained();
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -210,8 +210,8 @@ public class DetectorControllerTest {
         when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
         when(trace.startSpan("find-detectors-to-train-next", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
 
-        controllerUnderTest.findByNextRun(httpHeaders);
-        verify(detectorService, times(1)).getByTrainingNextRunLessThan();
+        controllerUnderTest.getNextDetectorsToTrain(httpHeaders);
+        verify(detectorService, times(1)).getDetectorsToBeTrained();
     }
 
     @Test
@@ -223,8 +223,8 @@ public class DetectorControllerTest {
         when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
         when(trace.startSpan("update-detector-training-time", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
 
-        controllerUnderTest.updateTrainingRunTime(uuid, timestamp, httpHeaders);
-        verify(detectorService, times(1)).updateTrainingRunTime(uuid, timestamp);
+        controllerUnderTest.updateDetectorTrainingTime(uuid, timestamp, httpHeaders);
+        verify(detectorService, times(1)).updateDetectorTrainingTime(uuid, timestamp);
     }
 
     private void initTestObjects() {

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -20,6 +20,7 @@ import com.expedia.adaptivealerting.modelservice.exception.RecordNotFoundExcepti
 import com.expedia.adaptivealerting.modelservice.service.DetectorService;
 import com.expedia.adaptivealerting.modelservice.test.ObjectMother;
 import com.expedia.adaptivealerting.modelservice.tracing.Trace;
+import com.expedia.adaptivealerting.modelservice.util.DateUtil;
 import com.expedia.www.haystack.client.SpanContext;
 import com.expedia.www.haystack.client.Tracer;
 import com.expedia.www.haystack.client.dispatchers.NoopDispatcher;
@@ -216,7 +217,7 @@ public class DetectorControllerTest {
 
     @Test
     public void testUpdateDetectorTrainingTime() {
-        val timestamp = System.currentTimeMillis();
+        val timestamp = DateUtil.toUtcDate("2020-07-15 20:00:00").toInstant().toEpochMilli();
         val uuid = this.someUuid.toString();
         val testDetectorMappingSpanContext = new SpanContext(uuid, uuid, uuid);
         val testChildSpan = noOpsTracer.buildSpan("update-detector-training-time").asChildOf(testDetectorMappingSpanContext).start();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -202,6 +202,31 @@ public class DetectorControllerTest {
         verify(detectorService, times(1)).deleteDetector(someUuidStr);
     }
 
+    @Test
+    public void testFindByNextRun() {
+        val testDetectorMappingSpanContext = new SpanContext(UUID.randomUUID(), UUID.randomUUID(),
+            UUID.randomUUID());
+        val testChildSpan = noOpsTracer.buildSpan("find-detectors-to-train-next").asChildOf(testDetectorMappingSpanContext).start();
+        when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
+        when(trace.startSpan("find-detectors-to-train-next", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
+
+        controllerUnderTest.findByNextRun(httpHeaders);
+        verify(detectorService, times(1)).getByNextRunLessThanOrNull();
+    }
+
+    @Test
+    public void testUpdateTrainingRunTime() {
+        val timestamp = System.currentTimeMillis();
+        val uuid = this.someUuid.toString();
+        val testDetectorMappingSpanContext = new SpanContext(uuid, uuid, uuid);
+        val testChildSpan = noOpsTracer.buildSpan("update-detector-training-time").asChildOf(testDetectorMappingSpanContext).start();
+        when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
+        when(trace.startSpan("update-detector-training-time", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
+
+        controllerUnderTest.updateTrainingRunTime(uuid, timestamp, httpHeaders);
+        verify(detectorService, times(1)).updateTrainingRunTime(uuid, timestamp);
+    }
+
     private void initTestObjects() {
         this.someUuid = UUID.randomUUID();
         val mom = ObjectMother.instance();

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -203,7 +203,7 @@ public class DetectorControllerTest {
     }
 
     @Test
-    public void testFindByNextRun() {
+    public void testGetNextDetectorsToTrain() {
         val testDetectorMappingSpanContext = new SpanContext(UUID.randomUUID(), UUID.randomUUID(),
             UUID.randomUUID());
         val testChildSpan = noOpsTracer.buildSpan("find-detectors-to-train-next").asChildOf(testDetectorMappingSpanContext).start();
@@ -215,7 +215,7 @@ public class DetectorControllerTest {
     }
 
     @Test
-    public void testUpdateTrainingRunTime() {
+    public void testUpdateDetectorTrainingTime() {
         val timestamp = System.currentTimeMillis();
         val uuid = this.someUuid.toString();
         val testDetectorMappingSpanContext = new SpanContext(uuid, uuid, uuid);


### PR DESCRIPTION
* Adding scheduler information to `detectorConfig.trainingMetaData` inside detector document
* Creating API endpoint `getNextDetectorsToTrain` to get a list of detectors to be trained next
* Creating API endpoint `updateDetectorTrainingTime` to update training run timestamps upon training initiated.
* Modifying update detector endpoint to prevent overriding/loosing `trainingMetaData` if not passed in `PUT` payload