### PR TITLE
adding timestamp parameter to getDetectorsToTrain endpoint

### DIFF
--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorService.java
@@ -43,7 +43,7 @@ public interface DetectorService {
 
     List<Detector> getLastUsedDetectors(int noOfDays);
 
-    List<Detector> getDetectorsToBeTrained();
+    List<Detector> getDetectorsToBeTrained(long timestampMs);
 
     void updateDetector(String uuid, Detector detector);
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -105,7 +105,8 @@ public class DetectorServiceImpl implements DetectorService {
 
     @Override
     public List<Detector> getDetectorsToBeTrained(long timestampMs) {
-        val date = DateUtil.toUtcDateString(Instant.ofEpochMilli(timestampMs));
+        val trainInstant = Instant.ofEpochMilli(timestampMs);
+        val date = DateUtil.toUtcDateString(trainInstant);
         return repository.findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(date);
     }
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImpl.java
@@ -28,6 +28,7 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -103,9 +104,8 @@ public class DetectorServiceImpl implements DetectorService {
     }
 
     @Override
-    public List<Detector> getDetectorsToBeTrained() {
-        val now = DateUtil.now().toInstant();
-        val date = DateUtil.toUtcDateString(now);
+    public List<Detector> getDetectorsToBeTrained(long timestampMs) {
+        val date = DateUtil.toUtcDateString(Instant.ofEpochMilli(timestampMs));
         return repository.findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(date);
     }
 

--- a/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
+++ b/modelservice/src/main/java/com/expedia/adaptivealerting/modelservice/web/DetectorController.java
@@ -137,10 +137,10 @@ public class DetectorController {
 
     @GetMapping(path = "/getDetectorsToTrain", produces = "application/json")
     @ResponseStatus(HttpStatus.OK)
-    public List<Detector> getDetectorsToTrain(@RequestHeader HttpHeaders headers) {
+    public List<Detector> getDetectorsToTrain(@RequestParam Long timestampMs, @RequestHeader HttpHeaders headers) {
         SpanContext parentSpanContext = trace.extractParentSpan(headers);
         Span span = trace.startSpan("find-detectors-to-train-next", parentSpanContext);
-        val detectorList = service.getDetectorsToBeTrained();
+        val detectorList = service.getDetectorsToBeTrained(timestampMs);
         span.finish();
 
         return detectorList;

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/service/DetectorServiceImplTest.java
@@ -161,7 +161,7 @@ public class DetectorServiceImplTest {
 
     @Test
     public void testGetDetectorsToBeTrained() {
-        serviceUnderTest.getDetectorsToBeTrained();
+        serviceUnderTest.getDetectorsToBeTrained(1595152176000L);
         verify(repository, times(1)).findByDetectorConfig_TrainingMetaData_DateTrainingNextRunLessThan(anyString());
     }
 

--- a/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
+++ b/modelservice/src/test/java/com/expedia/adaptivealerting/modelservice/web/DetectorControllerTest.java
@@ -211,8 +211,8 @@ public class DetectorControllerTest {
         when(trace.extractParentSpan(httpHeaders)).thenReturn(testDetectorMappingSpanContext);
         when(trace.startSpan("find-detectors-to-train-next", testDetectorMappingSpanContext)).thenReturn(testChildSpan);
 
-        controllerUnderTest.getDetectorsToTrain(httpHeaders);
-        verify(detectorService, times(1)).getDetectorsToBeTrained();
+        controllerUnderTest.getDetectorsToTrain(1595152176000L, httpHeaders);
+        verify(detectorService, times(1)).getDetectorsToBeTrained(1595152176000L);
     }
 
     @Test


### PR DESCRIPTION
Adding a timestamp parameter to `getDetectorsToTrain` endpoint, so it can retrieve a list of detectors to be trained at specific timestamp value.